### PR TITLE
fix(terraform): node decommissioning

### DIFF
--- a/terraform/node/decommission.sh
+++ b/terraform/node/decommission.sh
@@ -1,5 +1,11 @@
 set -e
 
+if [[ $3 == 'true' ]]; then
+  echo "Safety switch is ON, preventing node decommissioning" && exit 1
+fi
+
+echo "Safety switch is OFF, proceeding to node decommissioning"
+
 echo "aws ecs list-tasks --region $1 --cluster $2"
 tasks=$(aws ecs list-tasks --region $1 --cluster $2)
 echo $tasks
@@ -16,7 +22,11 @@ fi
 task_id=$(echo $task_arns | jq '.[0]' | awk -F/ '{print $NF}' | tr -d '"')
 # for some fucking reason debian doesn't have `pwait` as part of `procps` package,
 # so we do the dirty `tail` hack in order to wait before process exits
-command="bash -c 'pkill -SIGUSR1 pid1 && while sleep 60; do echo 'Decommissioning...'; done & tail -f --pid=\$(pgrep irn | tr -d '\n') /dev/null'"
+command="bash -c 'pkill -SIGUSR1 irn'"
 echo "aws ecs execute-command --region $1 --cluster $2 --task $task_id --interactive"
 echo "command: $command"
 aws ecs execute-command --region $1 --cluster $2 --container $2 --task $task_id --command "$command" --interactive
+
+# After receiving SIGUSR1 the node will ignore SIGTERMs sent by the ECS. Make sure that we won't issue SIGTERM too quicky.
+# Probably unnecessary, but just in case.
+sleep 1

--- a/terraform/node/variables.tf
+++ b/terraform/node/variables.tf
@@ -110,3 +110,8 @@ variable "ebs_volume_size" {
 variable "cache_buster" {
   type = string
 }
+
+variable "decommission_safety_switch" {
+  type    = bool
+  default = true
+}


### PR DESCRIPTION
# Description

Decommissioning has been broken for quite some time now, after we migrated to EC2 the whole process became somewhat easier, because now we can wait for the leaving migrations to finish outside of the script.

This PR fixes decommissioning and also adds a safety switch to prevent unintentional decommissions of nodes.

Relay follow up PR: https://github.com/WalletConnect/rs-relay/pull/1461

## How Has This Been Tested?

Manually on staging

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
