### PR TITLE
fix(irn_api): metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,7 +29,7 @@ dependencies = [
 [[package]]
 name = "alloc"
 version = "0.1.0"
-source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.8.0#ad42551ea3e9f6ee1bf8513f267033b46c567867"
+source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.11.0#52e40c625e40fee07770eb7b1b82dd7fd17ae2fc"
 dependencies = [
  "metrics",
  "serde",
@@ -317,8 +317,8 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 0.2.12",
- "http-body",
- "hyper",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "itoa",
  "matchit",
  "memchr",
@@ -347,7 +347,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 0.2.12",
- "http-body",
+ "http-body 0.4.6",
  "mime",
  "rustversion",
  "tower-layer",
@@ -735,7 +735,7 @@ checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
 [[package]]
 name = "collections"
 version = "0.1.0"
-source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.8.0#ad42551ea3e9f6ee1bf8513f267033b46c567867"
+source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.11.0#52e40c625e40fee07770eb7b1b82dd7fd17ae2fc"
 
 [[package]]
 name = "colorchoice"
@@ -1441,7 +1441,7 @@ dependencies = [
 [[package]]
 name = "future"
 version = "0.1.0"
-source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.8.0#ad42551ea3e9f6ee1bf8513f267033b46c567867"
+source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.11.0#52e40c625e40fee07770eb7b1b82dd7fd17ae2fc"
 dependencies = [
  "metrics",
  "pin-project",
@@ -2307,10 +2307,10 @@ dependencies = [
 [[package]]
 name = "http"
 version = "0.1.0"
-source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.8.0#ad42551ea3e9f6ee1bf8513f267033b46c567867"
+source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.11.0#52e40c625e40fee07770eb7b1b82dd7fd17ae2fc"
 dependencies = [
  "future",
- "hyper",
+ "hyper 1.3.1",
  "metrics",
  "tokio",
 ]
@@ -2327,6 +2327,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2335,6 +2346,16 @@ dependencies = [
  "bytes",
  "http 0.2.12",
  "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
 ]
 
 [[package]]
@@ -2367,7 +2388,7 @@ dependencies = [
  "futures-util",
  "h2",
  "http 0.2.12",
- "http-body",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -2380,13 +2401,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "tokio",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper",
+ "hyper 0.14.28",
  "native-tls",
  "tokio",
  "tokio-native-tls",
@@ -2481,7 +2514,7 @@ dependencies = [
  "bytes",
  "futures",
  "http 0.2.12",
- "hyper",
+ "hyper 0.14.28",
  "log",
  "rand 0.8.5",
  "tokio",
@@ -2600,7 +2633,7 @@ dependencies = [
  "env_logger 0.10.2",
  "envy",
  "futures",
- "hyper",
+ "hyper 0.14.28",
  "irn_api",
  "itertools 0.11.0",
  "network",
@@ -3180,11 +3213,12 @@ dependencies = [
 [[package]]
 name = "metrics"
 version = "0.1.0"
-source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.8.0#ad42551ea3e9f6ee1bf8513f267033b46c567867"
+source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.11.0#52e40c625e40fee07770eb7b1b82dd7fd17ae2fc"
 dependencies = [
  "once_cell",
  "opentelemetry",
  "opentelemetry-prometheus",
+ "opentelemetry_sdk",
  "pin-project",
  "prometheus",
  "smallvec",
@@ -3600,35 +3634,13 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.19.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4b8347cc26099d3aeee044065ecc3ae11469796b4d65d065a23a584ed92a6f"
+checksum = "900d57987be3f2aeb70d385fff9b27fb74c5723cc9a52d904d4f9c807a0667bf"
 dependencies = [
- "opentelemetry_api",
- "opentelemetry_sdk",
-]
-
-[[package]]
-name = "opentelemetry-prometheus"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a9f186f6293ebb693caddd0595e66b74a6068fa51048e26e0bf9c95478c639c"
-dependencies = [
- "opentelemetry",
- "prometheus",
- "protobuf",
-]
-
-[[package]]
-name = "opentelemetry_api"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed41783a5bf567688eb38372f2b7a8530f5a607a4b49d38dd7573236c23ca7e2"
-dependencies = [
- "fnv",
- "futures-channel",
- "futures-util",
- "indexmap 1.9.3",
+ "futures-core",
+ "futures-sink",
+ "js-sys",
  "once_cell",
  "pin-project-lite",
  "thiserror",
@@ -3636,25 +3648,47 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry_sdk"
-version = "0.19.0"
+name = "opentelemetry-prometheus"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b3a2a91fdbfdd4d212c0dcc2ab540de2c2bcbbd90be17de7a7daf8822d010c1"
+checksum = "30bbcf6341cab7e2193e5843f0ac36c446a5b3fccb28747afaeda17996dcd02e"
+dependencies = [
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prometheus",
+ "protobuf",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e90c7113be649e31e9a0f8b5ee24ed7a16923b322c3c5ab6367469c049d6b7e"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
- "dashmap",
- "fnv",
  "futures-channel",
  "futures-executor",
  "futures-util",
+ "glob",
  "once_cell",
- "opentelemetry_api",
+ "opentelemetry",
+ "ordered-float",
  "percent-encoding",
  "rand 0.8.5",
  "thiserror",
  "tokio",
  "tokio-stream",
+]
+
+[[package]]
+name = "ordered-float"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76df7075c7d4d01fdcb46c912dd17fba5b60c78ea480b475f2b6ab6f666584e"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -4291,8 +4325,8 @@ dependencies = [
  "futures-util",
  "h2",
  "http 0.2.12",
- "http-body",
- "hyper",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -5668,7 +5702,7 @@ checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 [[package]]
 name = "wc"
 version = "0.1.0"
-source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.8.0#ad42551ea3e9f6ee1bf8513f267033b46c567867"
+source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.11.0#52e40c625e40fee07770eb7b1b82dd7fd17ae2fc"
 dependencies = [
  "alloc",
  "collections",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ workspace = true
 
 [workspace.dependencies]
 cerberus = { git = "https://github.com/WalletConnect/cerberus.git", tag = "v0.11.0" }
-wc = { git = "https://github.com/WalletConnect/utils-rs.git", tag = "v0.8.0", default-features = false }
+wc = { git = "https://github.com/WalletConnect/utils-rs.git", tag = "v0.11.0", default-features = false }
 derive_more = { version = "=1.0.0-beta.6", features = [
     "display",
     "from",

--- a/crates/relay_irn/src/replication.rs
+++ b/crates/relay_irn/src/replication.rs
@@ -674,7 +674,7 @@ fn reconciliation_metrics(
         otel::KeyValue::new(name, metrics::value_bucket(num_items, &BUCKETS) as i64)
     };
 
-    counter.add(&otel::Context::new(), 1, &[
+    counter.add(1, &[
         items_kv("min", min.unwrap_or(0)),
         items_kv("max", max.unwrap_or(0)),
         items_kv("result", result),

--- a/crates/rocks/src/db/compaction/filters.rs
+++ b/crates/rocks/src/db/compaction/filters.rs
@@ -138,20 +138,16 @@ impl<C: cf::Column> Drop for ExpiredDataCompactionFilter<C> {
 
         let cf_name_kv = KeyValue::new("cf_name", C::NAME.as_str());
         let counter = wc::metrics::counter!("rocksdb_compaction_keys_processed");
-        let cx = wc::metrics::otel::Context::new();
 
-        counter.add(&cx, self.num_remove, &[
+        counter.add(self.num_remove, &[
             cf_name_kv.clone(),
             decision_kv("remove"),
         ]);
-        counter.add(&cx, self.num_change, &[
+        counter.add(self.num_change, &[
             cf_name_kv.clone(),
             decision_kv("change"),
         ]);
-        counter.add(&cx, self.num_keep, &[
-            cf_name_kv.clone(),
-            decision_kv("keep"),
-        ]);
+        counter.add(self.num_keep, &[cf_name_kv.clone(), decision_kv("keep")]);
 
         let elapsed = self.started.elapsed();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -384,31 +384,27 @@ fn update_rocksdb_metrics(db: &relay_rocks::RocksBackend, metrics: &mut RocksMet
         }
     };
 
-    let cx = otel::Context::new();
-
     for (name, stat) in stats {
         let name = format!("irn_{}", name.replace('.', "_"));
 
         match stat {
             relay_rocks::db::Statistic::Ticker(count) => {
-                metrics.counter(name).add(&cx, count, &[]);
+                metrics.counter(name).add(count, &[]);
             }
 
             relay_rocks::db::Statistic::Histogram(h) => {
                 // The distribution is already calculated for us by RocksDB, so we use
                 // `gauge`/`counter` here instead of `histogram`.
 
-                metrics
-                    .counter(format!("{name}_count"))
-                    .add(&cx, h.count, &[]);
-                metrics.counter(format!("{name}_sum")).add(&cx, h.sum, &[]);
+                metrics.counter(format!("{name}_count")).add(h.count, &[]);
+                metrics.counter(format!("{name}_sum")).add(h.sum, &[]);
 
                 let meter = metrics.gauge(name);
 
-                meter.observe(&cx, h.p50, &[otel::KeyValue::new("p", "50")]);
-                meter.observe(&cx, h.p95, &[otel::KeyValue::new("p", "95")]);
-                meter.observe(&cx, h.p99, &[otel::KeyValue::new("p", "99")]);
-                meter.observe(&cx, h.p100, &[otel::KeyValue::new("p", "100")]);
+                meter.observe(h.p50, &[otel::KeyValue::new("p", "50")]);
+                meter.observe(h.p95, &[otel::KeyValue::new("p", "95")]);
+                meter.observe(h.p99, &[otel::KeyValue::new("p", "99")]);
+                meter.observe(h.p100, &[otel::KeyValue::new("p", "100")]);
             }
         }
     }


### PR DESCRIPTION
# Description

`irn_api` metrics is currently broken in the relay, presumably because of a version mismatch in `opentelemetry`

This PR updates `utils-rs` version to match relay's.

## How Has This Been Tested?

Existing tests

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
