### PR TITLE
chore: remove `cerberus`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,20 +588,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cerberus"
-version = "0.2.0"
-source = "git+https://github.com/WalletConnect/cerberus.git?tag=v0.11.0#a2910bab0de24bb9e9fb5d67187e63a9e7a82dbf"
-dependencies = [
- "async-trait",
- "bitflags 2.5.0",
- "once_cell",
- "regex",
- "reqwest",
- "serde",
- "thiserror",
-]
-
-[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1270,15 +1256,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "enum-as-inner"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1413,21 +1390,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -2413,19 +2375,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper 0.14.28",
- "native-tls",
- "tokio",
- "tokio-native-tls",
-]
-
-[[package]]
 name = "iana-time-zone"
 version = "0.1.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2625,7 +2574,6 @@ dependencies = [
  "axum",
  "backoff",
  "base64 0.20.0",
- "cerberus",
  "chrono",
  "clap 4.5.4",
  "derivative",
@@ -3313,24 +3261,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "netlink-packet-core"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3589,48 +3519,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.64"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
-dependencies = [
- "bitflags 2.5.0",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.55",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.101"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dda2b0f344e78efc2facf7d195d098df0dd72151b26ab98da807afc26c198dff"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "opentelemetry"
@@ -4310,46 +4202,6 @@ dependencies = [
  "tokio-util",
  "tracing",
  "wc",
-]
-
-[[package]]
-name = "reqwest"
-version = "0.11.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.28",
- "hyper-tls",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "native-tls",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "rustls-pemfile",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "system-configuration",
- "tokio",
- "tokio-native-tls",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "winreg",
 ]
 
 [[package]]
@@ -5208,16 +5060,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-serde"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5656,18 +5498,6 @@ dependencies = [
  "quote",
  "syn 2.0.55",
  "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
-dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ test-cluster = [
 workspace = true
 
 [workspace.dependencies]
-cerberus = { git = "https://github.com/WalletConnect/cerberus.git", tag = "v0.11.0" }
 wc = { git = "https://github.com/WalletConnect/utils-rs.git", tag = "v0.11.0", default-features = false }
 derive_more = { version = "=1.0.0-beta.6", features = [
     "display",
@@ -67,8 +66,6 @@ api = { workspace = true }
 raft = { workspace = true }
 network = { workspace = true }
 relay_rocks = { workspace = true }
-
-cerberus = { workspace = true }
 wc = { workspace = true, features = ["alloc", "future", "metrics"] }
 
 anyhow = "1"

--- a/crates/relay_irn/src/cluster/keyspace/hashring/tests.rs
+++ b/crates/relay_irn/src/cluster/keyspace/hashring/tests.rs
@@ -630,30 +630,30 @@ fn key_remapping() {
     assert_key_remaps(&ring, num_keys, expected_moves, &mut mapping);
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+struct CustomPeer {
+    // This id comes from the outside, from the swarm, for instance.
+    external_id: PeerId,
+    // This is the id that is used for hashing. This way we can have deterministic hashing
+    // and therefore deterministic node placement on the ring. We can always extract the
+    // external id, when needed.
+    internal_id: PeerId,
+}
+
+impl From<CustomPeer> for PeerId {
+    fn from(peer: CustomPeer) -> PeerId {
+        peer.external_id
+    }
+}
+
+impl Hash for CustomPeer {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.internal_id.hash(state);
+    }
+}
+
 #[test]
 fn custom_peer() {
-    #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
-    struct CustomPeer {
-        // This id comes from the outside, from the swarm, for instance.
-        external_id: PeerId,
-        // This is the id that is used for hashing. This way we can have deterministic hashing
-        // and therefore deterministic node placement on the ring. We can always extract the
-        // external id, when needed.
-        internal_id: PeerId,
-    }
-
-    impl From<CustomPeer> for PeerId {
-        fn from(peer: CustomPeer) -> PeerId {
-            peer.external_id
-        }
-    }
-
-    impl Hash for CustomPeer {
-        fn hash<H: Hasher>(&self, state: &mut H) {
-            self.internal_id.hash(state);
-        }
-    }
-
     // These peers are pre-selected and are not random.
     let peers = preset_peers();
 


### PR DESCRIPTION
# Description

- Removes `cerberus` dependency;
- Cleans up warnings in tests.

## How Has This Been Tested?

Untested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
