### PR TITLE
feat: restart on sigint

### DIFF
--- a/docs/using-client-cli.md
+++ b/docs/using-client-cli.md
@@ -93,6 +93,8 @@ Peer ID: 12D3KooWBQGYh92KEdxUW5UUdy7BvAW96hvYLBMmjzy6X2XsY2HA
 irn node start -w ./working-dir -c ./config.toml
 ```
 
+**Note:** Interrupting a running node via `ctrl+c`/`SIGINT` would put the node into the `restarting` state, which assumes a very short downtime. Having one node in the cluster in `restarting` state prevents other nodes from restarting or leaving the cluster. If the node is being shutdown for a long period of time, it should be decommissioned instead. Decommissioning can only be done externally (see below).
+
 ### Running a node in detached mode
 
 ```bash

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -2,21 +2,19 @@ use {
     anyhow::Context as _,
     futures::Future,
     irn::ShutdownReason,
-    std::pin::pin,
     tokio::signal::unix::{self, Signal, SignalKind},
 };
 
 pub fn shutdown_listener() -> anyhow::Result<impl Future<Output = ShutdownReason>> {
+    let mut sigint = listener(SignalKind::interrupt())?;
     let mut sigterm = listener(SignalKind::terminate())?;
     let mut sigusr1 = listener(SignalKind::user_defined1())?;
 
     Ok(async move {
-        let mut sigterm = pin!(sigterm.recv());
-        let mut sigusr1 = pin!(sigusr1.recv());
-
         tokio::select! {
-            _ = &mut sigterm => ShutdownReason::Restart,
-            _ = &mut sigusr1 => ShutdownReason::Decommission,
+            _ = sigint.recv() => ShutdownReason::Restart,
+            _ = sigterm.recv() => ShutdownReason::Restart,
+            _ = sigusr1.recv() => ShutdownReason::Decommission,
         }
     })
 }


### PR DESCRIPTION
# Description

This adds a `SIGINT` listener which puts the node in `restarting` state.

## How Has This Been Tested?

Manually.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
