### PR TITLE
fix: add client auth key helpers

### DIFF
--- a/crates/irn/src/commands/storage.rs
+++ b/crates/irn/src/commands/storage.rs
@@ -1,7 +1,7 @@
 use {
     irn_api::{
+        auth::{Auth, PublicKey},
         client,
-        namespace::{Auth, PublicKey},
         Client,
         Key,
         SigningKey,

--- a/crates/irn_api/src/client.rs
+++ b/crates/irn_api/src/client.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        namespace,
+        auth,
         rpc,
         Cursor,
         Field,
@@ -67,7 +67,7 @@ pub struct Config {
 
     pub connection_timeout: Duration,
     pub udp_socket_count: usize,
-    pub namespaces: Vec<namespace::Auth>,
+    pub namespaces: Vec<auth::Auth>,
 }
 
 #[derive(Clone)]
@@ -77,7 +77,7 @@ pub struct Client {
     /// UDP buffer size configuration, so in order to be able to sustain high
     /// throughput we need to spread the load across multiple UDP sockets.
     inner: Arc<[NetworkClient]>,
-    namespaces: Arc<HashMap<namespace::PublicKey, namespace::Auth>>,
+    namespaces: Arc<HashMap<auth::PublicKey, auth::Auth>>,
 
     shadowing: Option<Shadowing>,
 
@@ -123,7 +123,7 @@ impl Client {
         Self::new_inner(cfg, "", shadowing)
     }
 
-    pub fn namespaces(&self) -> &HashMap<namespace::PublicKey, namespace::Auth> {
+    pub fn namespaces(&self) -> &HashMap<auth::PublicKey, auth::Auth> {
         &self.namespaces
     }
 
@@ -448,7 +448,7 @@ impl Client {
 /// Client part of the [`network::Handshake`].
 #[derive(Clone)]
 struct Handshake {
-    namespaces: Arc<HashMap<namespace::PublicKey, namespace::Auth>>,
+    namespaces: Arc<HashMap<auth::PublicKey, auth::Auth>>,
 }
 
 impl network::Handshake for Handshake {

--- a/crates/irn_api/src/lib.rs
+++ b/crates/irn_api/src/lib.rs
@@ -14,11 +14,9 @@ pub use {
 pub mod client;
 #[cfg(feature = "client")]
 pub use client::Client;
-
+pub mod auth;
 #[cfg(feature = "server")]
 pub mod server;
-
-pub mod namespace;
 
 pub mod rpc {
     use {
@@ -53,7 +51,7 @@ pub mod rpc {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Key {
-    pub namespace: Option<namespace::PublicKey>,
+    pub namespace: Option<auth::PublicKey>,
     pub bytes: Vec<u8>,
 }
 
@@ -207,8 +205,8 @@ pub struct Subscribe {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct NamespaceAuth {
-    pub namespace: namespace::PublicKey,
-    pub signature: namespace::Signature,
+    pub namespace: auth::PublicKey,
+    pub signature: auth::Signature,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -219,7 +217,7 @@ pub struct PubsubEventPayload {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct HandshakeRequest {
-    pub auth_nonce: namespace::Nonce,
+    pub auth_nonce: auth::Nonce,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/irn_api/src/server.rs
+++ b/crates/irn_api/src/server.rs
@@ -1,6 +1,6 @@
 pub use network::{inbound::RpcHandler, ServerConfig as Config};
 use {
-    crate::{namespace, HandshakeRequest, HandshakeResponse},
+    crate::{auth, HandshakeRequest, HandshakeResponse},
     futures_util::{Future, SinkExt},
     std::{collections::HashSet, io, sync::Arc, time::Duration},
     wc::future::FutureExt,
@@ -20,7 +20,7 @@ struct Handshake;
 
 #[derive(Clone, Debug)]
 pub struct HandshakeData {
-    pub namespaces: Arc<HashSet<namespace::PublicKey>>,
+    pub namespaces: Arc<HashSet<auth::PublicKey>>,
 }
 
 impl network::Handshake for Handshake {
@@ -36,7 +36,7 @@ impl network::Handshake for Handshake {
                 .initiate_handshake::<HandshakeRequest, HandshakeResponse>()
                 .await?;
 
-            let auth_nonce = namespace::Nonce::generate();
+            let auth_nonce = auth::Nonce::generate();
 
             tx.send(HandshakeRequest { auth_nonce }).await?;
 

--- a/src/network.rs
+++ b/src/network.rs
@@ -7,7 +7,7 @@ use {
         Error,
         Node,
     },
-    api::{namespace, server::HandshakeData},
+    api::{auth, server::HandshakeData},
     async_trait::async_trait,
     derive_more::AsRef,
     futures::{
@@ -234,7 +234,7 @@ fn prepare_key(key: api::Key, conn_info: &ConnectionInfo<HandshakeData>) -> api:
         // information with the user key etc.
         _ => {
             let prefix_len = if key.namespace.is_some() {
-                namespace::PUBLIC_KEY_LEN
+                auth::PUBLIC_KEY_LEN
             } else {
                 0
             };

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,5 +1,5 @@
 use {
-    api::{namespace, Key, Multiaddr, SigningKey},
+    api::{auth, Key, Multiaddr},
     futures::{
         stream::{self, FuturesUnordered},
         FutureExt,
@@ -228,7 +228,7 @@ async fn pubsub(cluster: &test::Cluster<Context>) {
         .values()
         .map(|n| {
             api::Client::new(api::client::Config {
-                key: SigningKey::generate(&mut rand::thread_rng()),
+                key: auth::client_key_from_secret(b"test").unwrap(),
                 nodes: [(n.identity().peer_id.id, n.identity().api_addr.clone())]
                     .into_iter()
                     .collect(),
@@ -328,7 +328,7 @@ async fn pubsub(cluster: &test::Cluster<Context>) {
 async fn namespaces(cluster: &test::Cluster<Context>) {
     let namespaces = (0..2)
         .map(|i| {
-            let auth = namespace::Auth::from_secret(
+            let auth = auth::Auth::from_secret(
                 b"namespace_master_secret",
                 format!("namespace{i}").as_bytes(),
             )
@@ -343,7 +343,7 @@ async fn namespaces(cluster: &test::Cluster<Context>) {
     let node = &cluster.nodes().values().next().unwrap();
 
     let config = api::client::Config {
-        key: SigningKey::generate(&mut rand::thread_rng()),
+        key: auth::client_key_from_secret(b"test").unwrap(),
         nodes: [(node.identity().peer_id.id, node.identity().api_addr.clone())]
             .into_iter()
             .collect(),


### PR DESCRIPTION
# Description

Changes:
- renamed `irn_api::namespace` -> `irn_api::auth`;
- added a method to create client auth-specific keypair from a secret (required to integrate the latest API changes into the relay).

Relay PR: https://github.com/WalletConnect/rs-relay/pull/1543.

## How Has This Been Tested?

Manually.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
