### PR TITLE
fix: cli config defaults

### DIFF
--- a/crates/irn/default_config.toml
+++ b/crates/irn/default_config.toml
@@ -25,7 +25,7 @@ warmup_delay = 45000
 # group = 1
 
 [authorization]
-disable = false
+enable = true
 is_consensus_member = false
 clients = []
 consensus_candidates = []

--- a/crates/irn/src/commands/node/config.rs
+++ b/crates/irn/src/commands/node/config.rs
@@ -46,7 +46,7 @@ pub struct Server {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Authorization {
-    pub disable: bool,
+    pub enable: bool,
     pub clients: Vec<PeerId>,
     pub consensus_candidates: Vec<PeerId>,
     pub is_consensus_member: bool,
@@ -117,7 +117,6 @@ impl Config {
                 config::FileFormat::Toml,
             ))
             .add_source(config::File::new(path, config::FileFormat::Toml).required(true))
-            .add_source(config::Environment::with_prefix("IRN"))
             .build()?
             .try_deserialize()
     }

--- a/crates/irn/src/commands/node/start.rs
+++ b/crates/irn/src/commands/node/start.rs
@@ -30,7 +30,7 @@ pub struct StartCmd {
     /// The directory will be created if it doesn't exist.
     working_dir: Option<String>,
 
-    #[clap(short, long)]
+    #[clap(short, long, default_value = "config.toml")]
     /// Node configuration file.
     ///
     /// The path is relative to the working directory.
@@ -130,7 +130,7 @@ pub async fn exec(args: StartCmd) -> anyhow::Result<()> {
         None
     };
 
-    let (authorized_clients, authorized_raft_candidates) = if !config.authorization.disable {
+    let (authorized_clients, authorized_raft_candidates) = if config.authorization.enable {
         (
             Some(HashSet::from_iter(config.authorization.clients)),
             Some(HashSet::from_iter(


### PR DESCRIPTION
# Description

Changes:
- CLI config `authorization.disabled` is replaced with `authorization.enable`, which is `true` by default;
- `node start` command `--config` now has a default value of `config.toml`.

## How Has This Been Tested?

Manually.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
