### PR TITLE
fix(actions): sticking to the tag version instead of master branch in the shared GitHub action

### DIFF
--- a/.github/workflows/ci_terraform.yaml
+++ b/.github/workflows/ci_terraform.yaml
@@ -29,4 +29,4 @@ jobs:
         with:
           submodules: recursive
       - id: fmt
-        uses: WalletConnect/actions/actions/fmt-check-terraform@master
+        uses: WalletConnect/actions/actions/fmt-check-terraform@2.4.3


### PR DESCRIPTION
# Description

This PR sticking to the [2.4.3 tag version](https://github.com/WalletConnect/actions/releases) instead of the master branch in the shared `WalletConnect/actions` GitHub Action.

## How Has This Been Tested?

Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
