### PR TITLE
fix: auth & keys quality-of-life additions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3555,6 +3555,7 @@ name = "irn_api"
 version = "0.1.0"
 dependencies = [
  "async-stream",
+ "data-encoding",
  "derive_more 1.0.0-beta.6",
  "ed25519-dalek",
  "futures",
@@ -6492,9 +6493,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
@@ -6515,9 +6516,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",

--- a/crates/core/src/test.rs
+++ b/crates/core/src/test.rs
@@ -128,7 +128,7 @@ where
 
     // TODO: convert into a unit test once replication machinery is properly
     // isolated
-    async fn cluster_view_version_validation(&mut self) {
+    async fn cluster_view_version_validation(&self) {
         tracing::info!("Cluster view version validation");
 
         let mismatching_version = u128::MAX;
@@ -175,7 +175,7 @@ where
             .await;
     }
 
-    async fn replication_and_read_repairs(&mut self) {
+    async fn replication_and_read_repairs(&self) {
         const RECORDS_NUM: usize = 10000;
         const REQUEST_CONCURRENCY: usize = 100;
 

--- a/crates/irn_api/Cargo.toml
+++ b/crates/irn_api/Cargo.toml
@@ -34,6 +34,7 @@ ring = "0.17"
 serde-big-array = "0.5"
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
 ed25519-dalek = "2.1"
+data-encoding = "2.6"
 
 [dev-dependencies]
 static_assertions = "1.1"

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -27,7 +27,12 @@ use {
     wc::metrics::{Lazy, OtelTaskMetricsRecorder},
 };
 pub use {
-    libp2p::{identity::Keypair, multihash::Multihash, Multiaddr, PeerId},
+    libp2p::{
+        identity::{ed25519, Keypair, PublicKey},
+        multihash::Multihash,
+        Multiaddr,
+        PeerId,
+    },
     quinn::{ConnectionError, WriteError},
     rpc::Rpc,
 };

--- a/crates/raft/src/test.rs
+++ b/crates/raft/src/test.rs
@@ -158,13 +158,13 @@ async fn cluster_suite<Sp: ServerSpawner<C> + Clone>(
 
     let ch_req = |change| ProposeChangeRequest { change };
 
-    let mut n1 = run_node(0).await.unwrap();
-    let mut n2 = run_node(1).await.unwrap();
+    let n1 = run_node(0).await.unwrap();
+    let n2 = run_node(1).await.unwrap();
 
     // quorum isn't formed yet (2/5)
     assert!(n1.raft.propose_change(ch_req(Change::Incr)).await.is_err());
 
-    let mut n3 = run_node(2).await.unwrap();
+    let n3 = run_node(2).await.unwrap();
 
     // wait for leader to be elected.
     sleep(Duration::from_millis(200)).await;
@@ -187,7 +187,7 @@ async fn cluster_suite<Sp: ServerSpawner<C> + Clone>(
     n2.assert_state(1).await;
     n3.assert_state(1).await;
 
-    let mut n4 = run_node(3).await.unwrap();
+    let n4 = run_node(3).await.unwrap();
     n4.assert_state(1).await;
 
     n4.raft.propose_change(ch_req(Change::Incr)).await.unwrap();
@@ -201,7 +201,7 @@ async fn cluster_suite<Sp: ServerSpawner<C> + Clone>(
 
     // We can run a new learner node without errors, but it won't receive any state
     // updates until we explicitly add it to the cluster.
-    let mut n6 = run_node(5).await.unwrap();
+    let n6 = run_node(5).await.unwrap();
 
     // add learner
 
@@ -272,7 +272,7 @@ struct TestNode {
 }
 
 impl TestNode {
-    async fn assert_state(&mut self, counter: u64) {
+    async fn assert_state(&self, counter: u64) {
         tokio::time::timeout(Duration::from_secs(10), async {
             let mut updates = self.raft.updates();
             loop {

--- a/crates/rocks/src/db/compaction/filters.rs
+++ b/crates/rocks/src/db/compaction/filters.rs
@@ -50,7 +50,7 @@ impl<C: cf::Column> ExpiredDataCompactionFilter<C> {
         }
     }
 
-    fn filter_internal(&mut self, _level: u32, _key: &[u8], value: &[u8]) -> Decision {
+    fn filter_internal(&self, _level: u32, _key: &[u8], value: &[u8]) -> Decision {
         if let Ok(value) = deserialize::<DataContext<C::ValueType>>(value) {
             // Data context may not have a payload if it was initialized from the merge
             // operator with defaults.


### PR DESCRIPTION
# Description

- Adds some quality-of-life functions to help decode and convert between different key formats;
- Private key validation command for the CLI;
- Exposes `PeerId` conversion methods for easier debugging on the API consumer side.

## How Has This Been Tested?

Manually.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
