### PR TITLE
fix: remove automatic ip detection

### DIFF
--- a/crates/irn/src/commands/node/start.rs
+++ b/crates/irn/src/commands/node/start.rs
@@ -176,7 +176,7 @@ pub async fn exec(args: StartCmd) -> anyhow::Result<()> {
     let config = node::Config {
         id: PeerId::from_public_key(&config.identity.private_key.public()),
         keypair: config.identity.private_key,
-        server_addr: Some(config.server.bind_address),
+        server_addr: config.server.bind_address,
         replica_api_server_port: config.server.server_port,
         coordinator_api_server_port: config.server.client_port,
         raft_server_port: config.server.raft_port,

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,10 +26,7 @@ pub struct Config {
     pub is_raft_voter: bool,
 
     /// [`Ipv4Addr`] to bind the servers to.
-    ///
-    /// If not specified the node will try to automatically detect its own
-    /// public address.
-    pub server_addr: Option<Ipv4Addr>,
+    pub server_addr: Ipv4Addr,
 
     /// Port of the Raft server.
     pub raft_server_port: u16,
@@ -193,7 +190,7 @@ struct RawConfig {
 
     is_raft_voter: Option<bool>,
 
-    server_addr: Option<Ipv4Addr>,
+    server_addr: Ipv4Addr,
     raft_server_port: Option<u16>,
     replica_api_server_port: Option<u16>,
     coordinator_api_server_port: Option<u16>,

--- a/src/consensus/mod.rs
+++ b/src/consensus/mod.rs
@@ -31,7 +31,6 @@ use {
         fmt::Debug,
         future::Future,
         io::{self, Cursor},
-        net::Ipv4Addr,
         sync::Arc,
         time::Duration,
     },
@@ -272,7 +271,6 @@ impl Consensus {
     /// Spawns a new [`Consensus`] task and returns it's handle.
     pub async fn new(
         cfg: &Config,
-        server_addr: Ipv4Addr,
         network: Network,
         stake_validator: Option<contract::StakeValidator>,
     ) -> Result<Consensus, InitializationError> {
@@ -298,7 +296,7 @@ impl Consensus {
         let (tx, mut state) = watch::channel(None);
         let storage_adapter = storage::Adapter::new(cfg.raft_dir.clone(), tx);
 
-        let server_addr = socketaddr_to_multiaddr((server_addr, cfg.raft_server_port));
+        let server_addr = socketaddr_to_multiaddr((cfg.server_addr, cfg.raft_server_port));
 
         let bootstrap_nodes: Option<HashMap<_, _>> = cfg
             .bootstrap_nodes

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,14 +14,7 @@ use {
         PrometheusHandle,
     },
     serde::{Deserialize, Serialize},
-    std::{
-        fmt::Debug,
-        future::Future,
-        io,
-        net::{IpAddr, Ipv4Addr},
-        pin::pin,
-        time::Duration,
-    },
+    std::{fmt::Debug, future::Future, io, pin::pin, time::Duration},
     tap::Pipe,
     time::{macros::datetime, OffsetDateTime},
     xxhash_rust::xxh3::Xxh3Builder,
@@ -134,20 +127,7 @@ pub async fn run(
     let storage = Storage::new(cfg).map_err(Error::Storage)?;
     let network = Network::new(cfg)?;
 
-    let server_addr = if let Some(addr) = cfg.server_addr {
-        addr
-    } else {
-        if_addrs::get_if_addrs()
-            .map_err(Error::ReadNetworkInterfaces)?
-            .iter()
-            .find_map(|interface| match interface.addr.ip() {
-                IpAddr::V4(ip) if is_global_ip(ip) => Some(ip),
-                _ => None,
-            })
-            .ok_or(Error::NoPublicIp)?
-    };
-
-    tracing::info!(%server_addr, node_id = %cfg.id, "Running");
+    tracing::info!(addr = %cfg.server_addr, node_id = %cfg.id, "Running");
 
     let stake_validator = if let Some(c) = &cfg.smart_contract {
         let rpc_url = &c.eth_rpc_url;
@@ -161,7 +141,7 @@ pub async fn run(
         None
     };
 
-    let consensus = Consensus::new(cfg, server_addr, network.clone(), stake_validator)
+    let consensus = Consensus::new(cfg, network.clone(), stake_validator)
         .await
         .map_err(Error::Consensus)?;
 
@@ -222,7 +202,7 @@ pub async fn run(
     let node = irn::Node::new(
         cluster::Node {
             id: cfg.id,
-            addr: socketaddr_to_multiaddr((server_addr, cfg.replica_api_server_port)),
+            addr: socketaddr_to_multiaddr((cfg.server_addr, cfg.replica_api_server_port)),
             region: cfg.region,
             organization: cfg.organization.clone(),
             eth_address: cfg.eth_address.clone(),
@@ -234,16 +214,9 @@ pub async fn run(
         Xxh3Builder::new(),
     );
 
-    Network::spawn_servers(
-        cfg,
-        server_addr,
-        node.clone(),
-        prometheus.clone(),
-        status_reporter,
-    )?;
+    Network::spawn_servers(cfg, node.clone(), prometheus.clone(), status_reporter)?;
 
-    let metrics_srv =
-        metrics::serve(cfg.clone(), server_addr, node.clone(), prometheus)?.pipe(tokio::spawn);
+    let metrics_srv = metrics::serve(cfg.clone(), node.clone(), prometheus)?.pipe(tokio::spawn);
 
     let node_clone = node.clone();
     let node_fut = async move {
@@ -295,21 +268,3 @@ pub async fn run(
     Clone, Copy, Debug, Default, Hash, Eq, PartialEq, Ord, PartialOrd, Deserialize, Serialize,
 )]
 pub struct TypeConfig;
-
-/// Copy-pasta of [`Ipv4Addr::is_global`] with unstable checks removed.
-///
-/// Should be good enough for our purposes.
-const fn is_global_ip(addr: Ipv4Addr) -> bool {
-    !(addr.octets()[0] == 0 // "This network"
-            || addr.is_private()
-            || addr.is_loopback()
-            || addr.is_link_local()
-            // addresses reserved for future protocols (`192.0.0.0/24`)
-            // .9 and .10 are documented as globally reachable so they're excluded
-            || (
-                addr.octets()[0] == 192 && addr.octets()[1] == 0 && addr.octets()[2] == 0
-                && addr.octets()[3] != 9 && addr.octets()[3] != 10
-            )
-            || addr.is_documentation()
-            || addr.is_broadcast())
-}

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -2,12 +2,7 @@ use {
     crate::{config::Config, network::rpc, Error, Node},
     irn::cluster::Consensus,
     metrics_exporter_prometheus::PrometheusHandle,
-    std::{
-        future::Future,
-        net::{Ipv4Addr, SocketAddr},
-        path::Path,
-        time::Duration,
-    },
+    std::{future::Future, net::SocketAddr, path::Path, time::Duration},
     sysinfo::{NetworkExt, NetworksExt},
     tap::{TapFallible, TapOptional},
     tokio::sync::oneshot,
@@ -178,13 +173,12 @@ fn find_storage_mount_point(mut path: &Path) -> Option<&Path> {
 
 pub(crate) fn serve(
     cfg: Config,
-    server_addr: Ipv4Addr,
     node: Node,
     prometheus: PrometheusHandle,
 ) -> Result<impl Future<Output = Result<(), Error>>, Error> {
     let prometheus_ = prometheus.clone();
 
-    let addr: SocketAddr = (server_addr, cfg.metrics_server_port).into();
+    let addr: SocketAddr = (cfg.server_addr, cfg.metrics_server_port).into();
 
     let (tx, rx) = oneshot::channel();
 

--- a/src/network.rs
+++ b/src/network.rs
@@ -49,7 +49,6 @@ use {
         collections::{HashMap, HashSet},
         fmt::{self, Debug},
         io,
-        net::Ipv4Addr,
         pin::Pin,
         sync::{Arc, RwLock},
         time::Duration,
@@ -1106,23 +1105,22 @@ impl Network {
 
     pub fn spawn_servers<S: StatusReporter>(
         cfg: &Config,
-        addr: Ipv4Addr,
         node: Node,
         prometheus: PrometheusHandle,
         status_reporter: Option<S>,
     ) -> Result<tokio::task::JoinHandle<()>, Error> {
         let server_config = ::network::ServerConfig {
-            addr: socketaddr_to_multiaddr((addr, cfg.replica_api_server_port)),
+            addr: socketaddr_to_multiaddr((cfg.server_addr, cfg.replica_api_server_port)),
             keypair: cfg.keypair.clone(),
         };
 
         let api_server_config = ::network::ServerConfig {
-            addr: socketaddr_to_multiaddr((addr, cfg.coordinator_api_server_port)),
+            addr: socketaddr_to_multiaddr((cfg.server_addr, cfg.coordinator_api_server_port)),
             keypair: cfg.keypair.clone(),
         };
 
         let admin_api_server_config = ::network::ServerConfig {
-            addr: socketaddr_to_multiaddr((addr, cfg.admin_api_server_port)),
+            addr: socketaddr_to_multiaddr((cfg.server_addr, cfg.admin_api_server_port)),
             keypair: cfg.keypair.clone(),
         };
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -870,7 +870,7 @@ fn new_node_config() -> Config {
         bootstrap_nodes: None,
         raft_dir: dir.join("raft"),
         keypair,
-        server_addr: Some([127, 0, 0, 1].into()),
+        server_addr: [127, 0, 0, 1].into(),
         metrics_server_port: next_port(),
         rocksdb_dir: dir.join("rocksdb"),
         rocksdb: RocksdbDatabaseConfig {


### PR DESCRIPTION
# Description

It doesn't work, even on AWS EC2 instances with public elastic interfaces attached.
We do this on the infra level now.

## How Has This Been Tested?

Existing tests

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
