### PR TITLE
fix: bind metrics server to all network interfaces

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -178,7 +178,7 @@ pub(crate) fn serve(
 ) -> Result<impl Future<Output = Result<(), Error>>, Error> {
     let prometheus_ = prometheus.clone();
 
-    let addr: SocketAddr = (cfg.server_addr, cfg.metrics_server_port).into();
+    let addr: SocketAddr = ([0, 0, 0, 0], cfg.metrics_server_port).into();
 
     let (tx, rx) = oneshot::channel();
 


### PR DESCRIPTION
# Description

Having issues binding to the public addr in EKS, this may help

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
