### PR TITLE
fix: validate min number of nodes

### DIFF
--- a/crates/core/src/cluster.rs
+++ b/crates/core/src/cluster.rs
@@ -233,6 +233,10 @@ impl<N: Node, K: Keyspace<N>> Cluster<N, K> {
             return Err(Error::UnknownNode);
         }
 
+        if self.nodes.iter().count() <= K::REPLICATION_FACTOR {
+            return Err(Error::TooFewNodes);
+        }
+
         let mut new_nodes = self.nodes.clone();
         new_nodes.remove(id);
 

--- a/crates/core/src/cluster/keyspace.rs
+++ b/crates/core/src/cluster/keyspace.rs
@@ -16,6 +16,9 @@ use {
 
 /// Keyspace functionality required by a [`Cluster`](super::Cluster).
 pub trait Keyspace<N: Node>: Clone + Send + Sync + 'static {
+    // Number of replicas in each replica set.
+    const REPLICATION_FACTOR: usize;
+
     /// Snapshot of the [`Keyspace`] state suitable for network transmission and
     /// persistent storage.
     type Snapshot<'a>: Serialize + DeserializeOwned;
@@ -301,6 +304,7 @@ where
     B: BuildHasher + Default + Clone + Send + Sync + 'static,
     S: sharding::ReplicationStrategy<N> + Default + Clone + Send + Sync + 'static,
 {
+    const REPLICATION_FACTOR: usize = RF;
     type Snapshot<'a> = ShardedSnapshot;
 
     fn new(nodes: &Nodes<N>) -> super::Result<Self> {

--- a/crates/core/src/cluster/test.rs
+++ b/crates/core/src/cluster/test.rs
@@ -634,4 +634,9 @@ fn cluster() {
 
     assert_eq!(cluster.version(), 11);
     assert_eq!(cluster.keyspace_version(), 2);
+
+    assert_eq!(
+        cluster.decommission_node(&4),
+        Err(cluster::Error::TooFewNodes)
+    );
 }


### PR DESCRIPTION
# Description

Validates the minimum amount of nodes in the cluster (> replication_factor).

It wasn't broken, as it errors anyway on num_nodes < RF, but the error was of `Bug` kind, which is incorrect.

## How Has This Been Tested?

Unit

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
