### PR TITLE
feat: admin API client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3524,10 +3524,12 @@ dependencies = [
  "clap 4.5.4",
  "config",
  "data-encoding",
+ "derive_more 1.0.0-beta.6",
  "ed25519-dalek",
  "eyre",
  "fork",
  "humantime",
+ "irn_admin_api",
  "irn_api",
  "irn_core",
  "irn_node",
@@ -3542,6 +3544,17 @@ dependencies = [
  "tokio",
  "tracing",
  "vergen-pretty",
+]
+
+[[package]]
+name = "irn_admin_api"
+version = "0.1.0"
+dependencies = [
+ "irn_rpc",
+ "postcard",
+ "serde",
+ "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -3642,6 +3655,7 @@ dependencies = [
  "futures",
  "hyper 0.14.28",
  "if-addrs 0.13.3",
+ "irn_admin_api",
  "irn_api",
  "irn_core",
  "irn_rpc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ derive_more = { version = "=1.0.0-beta.6", features = [
 ] }
 core = { package = "irn_core", path = "crates/core" }
 api = { package = "irn_api", path = "crates/irn_api", features = ["server"] }
+admin_api = { package = "irn_admin_api", path = "crates/admin_api" }
 raft = { path = "crates/raft" }
 irn_rpc = { path = "crates/rpc" }
 relay_rocks = { path = "crates/rocks" }
@@ -70,6 +71,7 @@ time = "0.3"
 irn = { package = "irn_core", path = "crates/core" }
 sharding = { path = "crates/sharding" }
 api = { workspace = true }
+admin_api = { workspace = true, features = ["server"] }
 raft = { workspace = true }
 irn_rpc = { workspace = true, features = ["server"] }
 relay_rocks = { workspace = true }
@@ -135,6 +137,7 @@ rand = { version = "0.8", optional = true }
 vergen-pretty = { version = "0.3", features = ["trace"] }
 
 [dev-dependencies]
+admin_api = { workspace = true, features = ["client", "server"] }
 tempfile = "3"
 test-log = "0.2"
 once_cell = "1.17"

--- a/crates/admin_api/Cargo.toml
+++ b/crates/admin_api/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "irn_admin_api"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lints]
+workspace = true
+
+[features]
+client = ["irn_rpc/client"]
+server = ["irn_rpc/server"]
+
+[dependencies]
+irn_rpc = { workspace = true }
+serde = "1"
+postcard = { version = "1.0", default-features = false, features = [
+    "alloc",
+    "use-std",
+] }
+
+thiserror = "1"
+tracing = "0.1"

--- a/crates/admin_api/src/client.rs
+++ b/crates/admin_api/src/client.rs
@@ -1,0 +1,139 @@
+use {
+    super::*,
+    irn_rpc::{
+        client::middleware::{Timeouts, WithTimeouts, WithTimeoutsExt as _},
+        identity::Keypair,
+        transport::NoHandshake,
+    },
+    std::{collections::HashSet, convert::Infallible, result::Result as StdResult, time::Duration},
+};
+
+/// Admin API client.
+#[derive(Clone)]
+pub struct Client {
+    rpc_client: RpcClient,
+    server_addr: Multiaddr,
+}
+
+type RpcClient = WithTimeouts<irn_rpc::quic::Client>;
+
+/// [`Client`] config.
+#[derive(Clone)]
+pub struct Config {
+    /// [`Keypair`] of the [`Client`].
+    pub keypair: Keypair,
+
+    /// Timeout of establishing a network connection.
+    pub connection_timeout: Duration,
+
+    /// Timeout of a [`Client`] operation.
+    pub operation_timeout: Duration,
+
+    /// [`Multiaddr`] of the Admin API server.
+    pub server_addr: Multiaddr,
+}
+
+impl Config {
+    pub fn new(server_addr: Multiaddr) -> Self {
+        Self {
+            keypair: Keypair::generate_ed25519(),
+            connection_timeout: Duration::from_secs(5),
+            operation_timeout: Duration::from_secs(10),
+            server_addr,
+        }
+    }
+
+    /// Overwrites [`Config::keypair`].
+    pub fn with_keypair(mut self, keypair: Keypair) -> Self {
+        self.keypair = keypair;
+        self
+    }
+}
+
+impl Client {
+    /// Creates a new [`Client`].
+    pub fn new(config: Config) -> StdResult<Self, CreationError> {
+        let rpc_client_config = irn_rpc::client::Config {
+            keypair: config.keypair,
+            known_peers: HashSet::new(),
+            handshake: NoHandshake,
+            connection_timeout: config.connection_timeout,
+        };
+
+        let rpc_client = irn_rpc::quic::Client::new(rpc_client_config)
+            .map_err(|err| CreationError(err.to_string()))?
+            .with_timeouts(Timeouts::new().with_default(config.operation_timeout));
+
+        Ok(Self {
+            rpc_client,
+            server_addr: config.server_addr,
+        })
+    }
+
+    pub fn set_server_addr(&mut self, addr: Multiaddr) {
+        self.server_addr = addr;
+    }
+
+    /// Gets [`ClusterView`].
+    pub async fn get_cluster_view(&self) -> Result<ClusterView> {
+        GetClusterView::send(&self.rpc_client, &self.server_addr, ())
+            .await
+            .map_err(Into::into)
+    }
+
+    /// Gets [`NodeStatus`].
+    pub async fn get_node_status(&self) -> Result<NodeStatus, GetNodeStatusError> {
+        GetNodeStatus::send(&self.rpc_client, &self.server_addr, ())
+            .await
+            .map_err(Error::from)?
+            .map_err(Error::Api)
+    }
+}
+
+/// Error of [`Client::new`].
+#[derive(Clone, Debug, thiserror::Error)]
+#[error("{_0}")]
+pub struct CreationError(String);
+
+/// Error of a [`Client`] operation.
+#[derive(Clone, Debug, thiserror::Error)]
+pub enum Error<A = Infallible> {
+    /// API error.
+    #[error("API: {0:?}")]
+    Api(A),
+
+    /// Transport error.
+    #[error("Transport: {0}")]
+    Transport(String),
+
+    /// Client is not authorized to perform the operation.
+    #[error("Client is not authorized to perform the operation")]
+    Unauthorized,
+
+    /// Operation timed out.
+    #[error("Operation timed out")]
+    Timeout,
+
+    /// Other error.
+    #[error("Other: {0}")]
+    Other(String),
+}
+
+impl<A> From<irn_rpc::client::Error> for Error<A> {
+    fn from(err: irn_rpc::client::Error) -> Self {
+        use irn_rpc::client::middleware::error_code;
+
+        let rpc_err = match err {
+            irn_rpc::client::Error::Transport(err) => return Self::Transport(err.to_string()),
+            irn_rpc::client::Error::Rpc(err) => err,
+        };
+
+        match rpc_err.code.as_ref() {
+            error_code::TIMEOUT => Self::Timeout,
+            _ => Self::Other(format!("{rpc_err:?}")),
+        }
+    }
+}
+
+/// [`Client`] operation [`Result`].
+pub type Result<T, A = Infallible> = std::result::Result<T, Error<A>>;

--- a/crates/admin_api/src/lib.rs
+++ b/crates/admin_api/src/lib.rs
@@ -1,0 +1,59 @@
+#![allow(clippy::manual_async_fn)]
+
+pub use irn_rpc::{identity, Multiaddr, PeerId};
+use {
+    irn_rpc as rpc,
+    serde::{Deserialize, Serialize},
+    std::collections::HashMap,
+};
+
+#[cfg(feature = "client")]
+pub mod client;
+#[cfg(feature = "client")]
+pub use client::Client;
+#[cfg(feature = "server")]
+pub mod server;
+#[cfg(feature = "server")]
+pub use server::Server;
+
+type GetClusterView = rpc::Unary<{ rpc::id(b"get_cluster_view") }, (), ClusterView>;
+type GetNodeStatus =
+    rpc::Unary<{ rpc::id(b"get_node_status") }, (), Result<NodeStatus, GetNodeStatusError>>;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ClusterView {
+    pub nodes: HashMap<PeerId, Node>,
+    pub cluster_version: u128,
+    pub keyspace_version: u64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Node {
+    pub id: PeerId,
+    pub state: NodeState,
+    pub addr: Multiaddr,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub enum NodeState {
+    Pulling,
+    Normal,
+    Restarting,
+    Decommissioning,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct NodeStatus {
+    pub node_version: u64,
+    pub eth_address: Option<String>,
+    pub stake_amount: f64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum GetNodeStatusError {
+    /// Node status provider is not available.
+    NotAvailable,
+
+    /// Internal server error.
+    Internal(String),
+}

--- a/crates/admin_api/src/server.rs
+++ b/crates/admin_api/src/server.rs
@@ -1,0 +1,89 @@
+use {
+    super::*,
+    irn_rpc::{
+        identity::Keypair,
+        middleware::Timeouts,
+        server::{
+            middleware::{MeteredExt as _, WithTimeoutsExt as _},
+            ConnectionInfo,
+        },
+        transport::{BiDirectionalStream, NoHandshake},
+    },
+    std::{future::Future, time::Duration},
+};
+
+/// [`Server`] config.
+pub struct Config {
+    /// [`Multiaddr`] of the server.
+    pub addr: Multiaddr,
+
+    /// [`Keypair`] of the server.
+    pub keypair: Keypair,
+
+    /// Timeout of a [`Server`] operation.
+    pub operation_timeout: Duration,
+}
+
+/// Admin API server.
+pub trait Server: Clone + Send + Sync + 'static {
+    /// Gets [`ClusterView`].
+    fn get_cluster_view(&self) -> impl Future<Output = ClusterView> + Send;
+
+    /// Gets [`NodeStatus`].
+    fn get_node_status(&self) -> impl Future<Output = GetNodeStatusResult> + Send;
+
+    /// Runs this [`Server`] using the provided [`Config`].
+    fn serve(self, cfg: Config) -> Result<impl Future<Output = ()>, Error> {
+        let rpc_server = Adapter { server: self }
+            .with_timeouts(Timeouts::new().with_default(cfg.operation_timeout))
+            .metered();
+
+        let rpc_server_config = irn_rpc::server::Config {
+            addr: cfg.addr,
+            keypair: cfg.keypair,
+        };
+
+        irn_rpc::quic::server::run(rpc_server, rpc_server_config, NoHandshake).map_err(Error)
+    }
+}
+
+pub type GetNodeStatusResult = Result<NodeStatus, GetNodeStatusError>;
+
+#[derive(Clone, Debug)]
+struct Adapter<S> {
+    server: S,
+}
+
+impl<S> rpc::Server for Adapter<S>
+where
+    S: Server,
+{
+    fn handle_rpc(
+        &self,
+        id: rpc::Id,
+        stream: BiDirectionalStream,
+        _conn_info: &ConnectionInfo,
+    ) -> impl Future<Output = ()> + Send {
+        async move {
+            let _ = match id {
+                GetClusterView::ID => {
+                    GetClusterView::handle(stream, |()| self.server.get_cluster_view()).await
+                }
+                GetNodeStatus::ID => {
+                    GetNodeStatus::handle(stream, |()| self.server.get_node_status()).await
+                }
+
+                id => return tracing::warn!("Unexpected RPC: {}", rpc::Name::new(id)),
+            }
+            .map_err(
+                |err| tracing::debug!(name = %rpc::Name::new(id), ?err, "Failed to handle RPC"),
+            );
+        }
+    }
+}
+
+impl<S> rpc::server::Marker for Adapter<S> {}
+
+#[derive(Debug, thiserror::Error)]
+#[error("{_0:?}")]
+pub struct Error(irn_rpc::quic::Error);

--- a/crates/irn/Cargo.toml
+++ b/crates/irn/Cargo.toml
@@ -11,7 +11,10 @@ path = "src/main.rs"
 [dependencies]
 irn_rpc = { path = "../rpc" }
 irn_api = { path = "../irn_api" }
+irn_admin_api = { path = "../admin_api" }
 irn_core = { path = "../core" }
+
+derive_more = { workspace = true, features = ["deref"] }
 
 clap = { version = "4", features = ["derive"] }
 eyre = "0.6"

--- a/crates/irn/src/commands/node/status.rs
+++ b/crates/irn/src/commands/node/status.rs
@@ -1,31 +1,30 @@
-use {
-    irn::PrivateKey,
-    irn_api::{client, Client},
-    irn_rpc::{identity::Keypair, quic},
-    std::{net::SocketAddr, time::Duration},
-};
+use {irn::Keypair, irn_rpc::Multiaddr};
 
 #[derive(Debug, clap::Args)]
 pub struct StatusCmd {
-    #[clap(short, long, env = "IRN_STORAGE_ADDRESS")]
-    address: SocketAddr,
+    #[clap(short, long, env = "IRN_ADMIN_API_ADDRESS")]
+    address: Multiaddr,
 
-    #[clap(short, long, env = "IRN_STORAGE_PRIVATE_KEY")]
-    /// Client private key used for authorization.
-    private_key: PrivateKey,
+    #[clap(
+        short = 'k',
+        long = "private_key",
+        env = "IRN_ADMIN_API_CLIENT_PRIVATE_KEY"
+    )]
+    /// Client keypair used for authorization.
+    keypair: Keypair,
 }
 
 struct StatusClient {
-    client: Client,
+    client: irn_admin_api::Client,
 }
 
 impl StatusClient {
-    pub fn new(client: Client) -> anyhow::Result<Self> {
+    pub fn new(client: irn_admin_api::Client) -> anyhow::Result<Self> {
         Ok(Self { client })
     }
 
     async fn status(&self) -> anyhow::Result<()> {
-        let status = self.client.status().await?;
+        let status = self.client.get_node_status().await?;
 
         println!("Network Version: {}", status.node_version);
         println!("Wallet Address: {}", status.eth_address.unwrap_or_default());
@@ -36,27 +35,9 @@ impl StatusClient {
 }
 
 pub async fn exec(cmd: StatusCmd) -> anyhow::Result<()> {
-    // Currently, the client doesn't use or verify the peer ID of the provided node
-    // address. So we can use any peer ID and not require it as an input parameter.
-    //
-    // TODO: consider figuring out a way to map addresses to peer IDs and have the
-    // CLI read that mapping when constructing the client.
-    //
-    let peer_id = Keypair::generate_ed25519().public().to_peer_id();
-    let address = (peer_id, quic::socketaddr_to_multiaddr(cmd.address));
-
-    let api_client = Client::new(client::Config {
-        key: cmd.private_key.0,
-        nodes: [address].into(),
-        shadowing_nodes: Default::default(),
-        shadowing_factor: 0.0,
-        shadowing_default_namespace: None,
-        request_timeout: Duration::from_secs(1),
-        max_operation_time: Duration::from_millis(2500),
-        connection_timeout: Duration::from_secs(1),
-        udp_socket_count: 1,
-        namespaces: Default::default(),
-    })?;
+    let api_client = irn_admin_api::Client::new(
+        irn_admin_api::client::Config::new(cmd.address).with_keypair(cmd.keypair.0),
+    )?;
 
     let status_client = StatusClient::new(api_client)?;
 

--- a/crates/irn/src/commands/storage.rs
+++ b/crates/irn/src/commands/storage.rs
@@ -1,12 +1,12 @@
 use {
-    irn::PrivateKey,
+    irn::Keypair,
     irn_api::{
         auth::{Auth, PublicKey},
         client,
         Client,
         Key,
     },
-    irn_rpc::{identity::Keypair, quic},
+    irn_rpc::quic,
     std::{net::SocketAddr, str::FromStr, time::Duration},
 };
 
@@ -57,7 +57,7 @@ pub struct StorageCmd {
 
     #[clap(long, env = "IRN_STORAGE_PRIVATE_KEY")]
     /// Client private key used for authorization.
-    private_key: PrivateKey,
+    private_key: Keypair,
 
     #[clap(long, env = "IRN_STORAGE_NAMESPACE_SECRET")]
     /// Secret key to initialize namespaces.
@@ -310,11 +310,13 @@ pub async fn exec(cmd: StorageCmd) -> anyhow::Result<()> {
 
     // Currently, the client doesn't use or verify the peer ID of the provided node
     // address. So we can use any peer ID and not require it as an input parameter.
-    let peer_id = Keypair::generate_ed25519().public().to_peer_id();
+    let peer_id = irn_rpc::identity::Keypair::generate_ed25519()
+        .public()
+        .to_peer_id();
     let address = (peer_id, quic::socketaddr_to_multiaddr(cmd.address));
 
     let client = Client::new(client::Config {
-        key: cmd.private_key.0,
+        keypair: cmd.private_key.0,
         nodes: [address].into(),
         shadowing_nodes: Default::default(),
         shadowing_factor: 0.0,

--- a/crates/irn_api/src/lib.rs
+++ b/crates/irn_api/src/lib.rs
@@ -1,13 +1,10 @@
 #![allow(clippy::manual_async_fn)]
 
+pub use irn_rpc::{Multiaddr, PeerId as NodeId};
 use {
     derive_more::AsRef,
     serde::{Deserialize, Serialize},
     std::{borrow::Cow, collections::HashSet},
-};
-pub use {
-    ed25519_dalek::SigningKey,
-    irn_rpc::{Multiaddr, PeerId as NodeId},
 };
 
 #[cfg(feature = "client")]
@@ -23,15 +20,7 @@ pub mod rpc {
         super::{Cardinality, Field, PubsubEventPayload, UnixTimestampSecs, Value},
         crate::Cursor,
         irn_rpc as rpc,
-        serde::{Deserialize, Serialize},
     };
-
-    #[derive(Clone, Debug, Serialize, Deserialize)]
-    pub struct StatusResponse {
-        pub node_version: u64,
-        pub eth_address: Option<String>,
-        pub stake_amount: f64,
-    }
 
     type Rpc<const ID: rpc::Id, Op, Out> = rpc::Unary<ID, Op, super::Result<Out>>;
 
@@ -55,7 +44,6 @@ pub mod rpc {
     pub type Publish = rpc::Oneshot<{ rpc::id(b"publish") }, super::Publish>;
     pub type Subscribe =
         rpc::Streaming<{ rpc::id(b"subscribe") }, super::Subscribe, PubsubEventPayload>;
-    pub type Status = Rpc<{ rpc::id(b"status") }, super::Status, StatusResponse>;
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,9 @@ pub enum Error {
     #[error("Failed to start API server: {0:?}")]
     ApiServer(#[from] api::Error),
 
+    #[error("Failed to start Admin API server: {0:?}")]
+    AdminApiServer(#[from] admin_api::server::Error),
+
     #[error("Failed to initialize networking: {0:?}")]
     Network(#[from] quic::Error),
 


### PR DESCRIPTION
# Description

- adds `admin_api` crate and moves `Server` impl into it
- impls Admin API client
- replaces `ed25519_dalek` secret key with `libp2p::Keypair` in `irn_api` (same thing under the hood)
- moves `status` rpc into Admin API

## How Has This Been Tested?

Existing integration tests

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
