### PR TITLE
fix(admin-api): restrict decommission_node

### DIFF
--- a/crates/admin_api/src/lib.rs
+++ b/crates/admin_api/src/lib.rs
@@ -98,4 +98,8 @@ pub enum DecommissionNodeError {
 
     /// Consensus error.
     Consensus(String),
+
+    /// The node serving the Admin API is not allowed to decommission the
+    /// requested node.
+    NotAllowed,
 }

--- a/src/consensus/mod.rs
+++ b/src/consensus/mod.rs
@@ -585,6 +585,11 @@ impl Raft {
 
         false
     }
+
+    pub fn is_voter(&self, peer_id: &libp2p::PeerId) -> bool {
+        let membership = self.inner.metrics().membership_config;
+        membership.voter_ids().any(|id| &id.0 == peer_id)
+    }
 }
 
 fn unauthorized_error() -> Error<raft::ClientWriteFail<TypeConfig>> {

--- a/src/network.rs
+++ b/src/network.rs
@@ -977,6 +977,13 @@ impl<S: StatusReporter> admin_api::Server for AdminApiServer<S> {
         let cluster = consensus.cluster();
 
         async move {
+            // Regular nodes are only allowed to decommission themselves, voter nodes can
+            // decommission any node.
+            let is_allowed = &id == self.node.id() || consensus.is_voter(self.node.id());
+            if !is_allowed {
+                return Err(Error::NotAllowed);
+            }
+
             let node = cluster.node(&id).ok_or(Error::UnknownNode)?;
             let node_state = cluster.node_state(&id).ok_or(Error::UnknownNode)?;
 


### PR DESCRIPTION
# Description

Restricts which nodes are allowed to decommission other nodes.
Regular nodes are only allowed to decommission themselves, voter nodes can decommission any node.

## How Has This Been Tested?

Existing tests

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
