### PR TITLE
fix: bump derive_more

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1877,18 +1877,18 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "1.0.0-beta.6"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7abbfc297053be59290e3152f8cbcd52c8642e0728b69ee187d991d4c1af08d"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
 dependencies = [
  "derive_more-impl",
 ]
 
 [[package]]
 name = "derive_more-impl"
-version = "1.0.0-beta.6"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bba3e9872d7c58ce7ef0fcf1844fcc3e23ef2a58377b50df35dd98e42a5726e"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3524,7 +3524,7 @@ dependencies = [
  "clap 4.5.4",
  "config",
  "data-encoding",
- "derive_more 1.0.0-beta.6",
+ "derive_more 1.0.0",
  "ed25519-dalek",
  "eyre",
  "fork",
@@ -3564,7 +3564,7 @@ version = "0.1.0"
 dependencies = [
  "async-stream",
  "data-encoding",
- "derive_more 1.0.0-beta.6",
+ "derive_more 1.0.0",
  "ed25519-dalek",
  "futures",
  "futures-util",
@@ -3601,7 +3601,7 @@ dependencies = [
  "criterion",
  "dashmap",
  "derivative",
- "derive_more 1.0.0-beta.6",
+ "derive_more 1.0.0",
  "difference",
  "env_logger 0.10.2",
  "fnv",
@@ -3650,7 +3650,7 @@ dependencies = [
  "chrono",
  "clap 4.5.4",
  "derivative",
- "derive_more 1.0.0-beta.6",
+ "derive_more 1.0.0",
  "env_logger 0.10.2",
  "envy",
  "futures",
@@ -3703,7 +3703,7 @@ version = "0.1.0"
 dependencies = [
  "backoff",
  "derivative",
- "derive_more 1.0.0-beta.6",
+ "derive_more 1.0.0",
  "futures",
  "indexmap",
  "libp2p",
@@ -5276,7 +5276,7 @@ name = "raft"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "derive_more 1.0.0-beta.6",
+ "derive_more 1.0.0",
  "futures",
  "irn_core",
  "openraft",
@@ -5479,7 +5479,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "chrono",
- "derive_more 1.0.0-beta.6",
+ "derive_more 1.0.0",
  "env_logger 0.10.2",
  "futures",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ workspace = true
 
 [workspace.dependencies]
 wc = { git = "https://github.com/WalletConnect/utils-rs.git", tag = "v0.14.1", default-features = false }
-derive_more = { version = "=1.0.0-beta.6", features = [
+derive_more = { version = "1.0.0", features = [
     "display",
     "from",
     "as_ref",


### PR DESCRIPTION
# Description

Bumps to the stable version as `alloy` depends on this version and trying to integrate it in Blockchain API

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
