### PR TITLE
fix(raft): init race condition

### DIFF
--- a/src/consensus/mod.rs
+++ b/src/consensus/mod.rs
@@ -392,8 +392,12 @@ impl Consensus {
 
 impl Raft {
     async fn init(&self, cfg: &Config, server_addr: &Multiaddr) -> Result<(), InitializationError> {
+        self.wait_init().await;
+
         let membership = self.metrics().membership_config;
         let nodes: &HashMap<_, _> = &membership.nodes().collect();
+
+        tracing::info!(%server_addr, ?nodes, "init");
 
         let node = nodes.get(&NodeId(self.id));
 


### PR DESCRIPTION
# Description

The race condition was causing the starting node to always try to add itself to the cluster, even when it was already a member.

## How Has This Been Tested?

Existing integration

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
