### PR TITLE
feat: configure max concurrent RPCs

### DIFF
--- a/crates/admin_api/src/server.rs
+++ b/crates/admin_api/src/server.rs
@@ -57,6 +57,7 @@ pub trait Server: Clone + Send + Sync + 'static {
         let rpc_server_config = irn_rpc::server::Config {
             addr: cfg.addr,
             keypair: cfg.keypair,
+            max_concurrent_rpcs: 100,
         };
 
         irn_rpc::quic::server::run(rpc_server, rpc_server_config, NoHandshake).map_err(Error)

--- a/crates/irn/src/commands/node/start.rs
+++ b/crates/irn/src/commands/node/start.rs
@@ -182,6 +182,8 @@ pub async fn exec(args: StartCmd) -> anyhow::Result<()> {
         raft_server_port: config.server.raft_port,
         admin_api_server_port: config.server.admin_port,
         metrics_server_port: config.server.metrics_port,
+        coordinator_api_max_concurrent_rpcs: 30000,
+        replica_api_max_concurrent_rpcs: 30000,
         is_raft_voter: false,
         bootstrap_nodes,
         known_peers,

--- a/crates/rpc/src/quic/client.rs
+++ b/crates/rpc/src/quic/client.rs
@@ -78,7 +78,7 @@ type OutboundConnectionHandlers<H> = IndexMap<Multiaddr, ConnectionHandler<H>>;
 impl<H: Handshake> Client<H> {
     /// Builds a new [`Client`] using the provided [`Config`].
     pub fn new(cfg: Config<H>) -> Result<Client<H>, super::Error> {
-        let transport_config = super::new_quinn_transport_config();
+        let transport_config = super::new_quinn_transport_config(64u32 * 1024);
         let socket_addr = SocketAddr::new(std::net::Ipv4Addr::new(0, 0, 0, 0).into(), 0);
         let endpoint =
             super::new_quinn_endpoint(socket_addr, &cfg.keypair, transport_config, None)?;

--- a/crates/rpc/src/quic/mod.rs
+++ b/crates/rpc/src/quic/mod.rs
@@ -24,7 +24,7 @@ mod metrics;
 #[error("{0}: invalid QUIC Multiaddr")]
 pub struct InvalidMultiaddrError(Multiaddr);
 
-fn new_quinn_transport_config() -> Arc<quinn::TransportConfig> {
+fn new_quinn_transport_config(max_concurrent_streams: u32) -> Arc<quinn::TransportConfig> {
     const STREAM_WINDOW: u32 = 16 * 1024 * 1024; // 16 MiB
 
     // Our tests are too slow and connections get dropped because of missing keep
@@ -35,7 +35,7 @@ fn new_quinn_transport_config() -> Arc<quinn::TransportConfig> {
     // Disable uni-directional streams and datagrams.
     transport
         .max_concurrent_uni_streams(0u32.into())
-        .max_concurrent_bidi_streams((128u32 * 1024).into())
+        .max_concurrent_bidi_streams(max_concurrent_streams.into())
         .datagram_receive_buffer_size(None)
         .keep_alive_interval(Some(Duration::from_millis(100)))
         .max_idle_timeout(Some(VarInt::from_u32(max_idle_timeout_ms).into()))

--- a/crates/rpc/src/quic/server.rs
+++ b/crates/rpc/src/quic/server.rs
@@ -22,7 +22,7 @@ pub fn run<H: Handshake>(
     cfg: Config,
     handshake: H,
 ) -> Result<impl Future<Output = ()>, Error> {
-    let transport_config = super::new_quinn_transport_config();
+    let transport_config = super::new_quinn_transport_config(cfg.max_concurrent_rpcs);
 
     let server_tls_config = libp2p_tls::make_server_config(&cfg.keypair)?;
     let mut server_config = quinn::ServerConfig::with_crypto(Arc::new(server_tls_config));

--- a/crates/rpc/src/server/mod.rs
+++ b/crates/rpc/src/server/mod.rs
@@ -19,6 +19,9 @@ pub struct Config {
 
     /// [`Keypair`] of the server.
     pub keypair: Keypair,
+
+    /// Maximum allowed amount of concurrent RPCs.
+    pub max_concurrent_rpcs: u32,
 }
 
 /// Info about an inbound connection.

--- a/crates/rpc/src/test.rs
+++ b/crates/rpc/src/test.rs
@@ -109,6 +109,7 @@ async fn suite() {
         let server_config = server::Config {
             addr: addr.clone(),
             keypair: keypair.clone(),
+            max_concurrent_rpcs: 10000,
         };
 
         clients.push(client.clone());

--- a/src/config.rs
+++ b/src/config.rs
@@ -43,6 +43,12 @@ pub struct Config {
     /// Port of the Prometheus metrics server.
     pub metrics_server_port: u16,
 
+    /// Maximum number of concurrent Replica API RPCs.
+    pub replica_api_max_concurrent_rpcs: u32,
+
+    /// Maximum number of concurrent Coordinator API RPCs.
+    pub coordinator_api_max_concurrent_rpcs: u32,
+
     /// List of known peers.
     pub known_peers: HashMap<PeerId, Multiaddr>,
 
@@ -139,6 +145,10 @@ impl Config {
             coordinator_api_server_port: raw.coordinator_api_server_port.unwrap_or(3012),
             admin_api_server_port: raw.admin_api_server_port.unwrap_or(3013),
             metrics_server_port: raw.metrics_server_port.unwrap_or(3014),
+            replica_api_max_concurrent_rpcs: raw.replica_api_max_concurrent_rpcs.unwrap_or(30000),
+            coordinator_api_max_concurrent_rpcs: raw
+                .coordinator_api_max_concurrent_rpcs
+                .unwrap_or(30000),
             bootstrap_nodes: raw.bootstrap_nodes,
             known_peers: known_peers_from_env()?,
             raft_dir: raw.raft_dir,
@@ -200,6 +210,9 @@ struct RawConfig {
     coordinator_api_server_port: Option<u16>,
     admin_api_server_port: Option<u16>,
     metrics_server_port: Option<u16>,
+
+    replica_api_max_concurrent_rpcs: Option<u32>,
+    coordinator_api_max_concurrent_rpcs: Option<u32>,
 
     bootstrap_nodes: Option<Vec<PeerId>>,
     raft_dir: PathBuf,

--- a/src/network.rs
+++ b/src/network.rs
@@ -1074,6 +1074,7 @@ impl Network {
         let server_config = irn_rpc::server::Config {
             addr: server_addr,
             keypair: cfg.keypair.clone(),
+            max_concurrent_rpcs: 1000,
         };
 
         let server = RaftRpcServer { raft }
@@ -1092,11 +1093,13 @@ impl Network {
         let replica_api_server_config = irn_rpc::server::Config {
             addr: socketaddr_to_multiaddr((cfg.server_addr, cfg.replica_api_server_port)),
             keypair: cfg.keypair.clone(),
+            max_concurrent_rpcs: cfg.replica_api_max_concurrent_rpcs,
         };
 
         let coordinator_api_server_config = irn_rpc::server::Config {
             addr: socketaddr_to_multiaddr((cfg.server_addr, cfg.coordinator_api_server_port)),
             keypair: cfg.keypair.clone(),
+            max_concurrent_rpcs: cfg.coordinator_api_max_concurrent_rpcs,
         };
 
         let default_timeout = Duration::from_millis(cfg.network_request_timeout);

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -881,6 +881,8 @@ fn new_node_config() -> Config {
         replica_api_server_port: next_port(),
         coordinator_api_server_port: next_port(),
         admin_api_server_port: next_port(),
+        replica_api_max_concurrent_rpcs: 10000,
+        coordinator_api_max_concurrent_rpcs: 10000,
         known_peers: HashMap::default(),
         bootstrap_nodes: None,
         raft_dir: dir.join("raft"),


### PR DESCRIPTION
# Description

Adds a configuration option to set max concurrent Replica API / Coordinator API RPCs.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
