### PR TITLE
feat(rpc): QUIC server: custom stream concurrency limiter

### DIFF
--- a/crates/admin_api/src/server.rs
+++ b/crates/admin_api/src/server.rs
@@ -55,6 +55,7 @@ pub trait Server: Clone + Send + Sync + 'static {
             .metered();
 
         let rpc_server_config = irn_rpc::server::Config {
+            name: "admin_api",
             addr: cfg.addr,
             keypair: cfg.keypair,
             max_concurrent_rpcs: 100,

--- a/crates/rpc/src/server/mod.rs
+++ b/crates/rpc/src/server/mod.rs
@@ -14,6 +14,9 @@ pub mod middleware;
 /// Server config.
 #[derive(Clone)]
 pub struct Config {
+    /// Server name. For metric purposes.
+    pub name: &'static str,
+
     /// [`Multiaddr`] of the server.
     pub addr: Multiaddr,
 

--- a/crates/rpc/src/test.rs
+++ b/crates/rpc/src/test.rs
@@ -107,6 +107,7 @@ async fn suite() {
         let client = quic::Client::new(client_config).expect("Client::new");
 
         let server_config = server::Config {
+            name: "test_server",
             addr: addr.clone(),
             keypair: keypair.clone(),
             max_concurrent_rpcs: 10000,

--- a/src/network.rs
+++ b/src/network.rs
@@ -1072,6 +1072,7 @@ impl Network {
         raft: consensus::Raft,
     ) -> Result<tokio::task::JoinHandle<()>, quic::Error> {
         let server_config = irn_rpc::server::Config {
+            name: "raft_api",
             addr: server_addr,
             keypair: cfg.keypair.clone(),
             max_concurrent_rpcs: 1000,
@@ -1091,12 +1092,14 @@ impl Network {
         status_reporter: Option<S>,
     ) -> Result<tokio::task::JoinHandle<()>, Error> {
         let replica_api_server_config = irn_rpc::server::Config {
+            name: "replica_api",
             addr: socketaddr_to_multiaddr((cfg.server_addr, cfg.replica_api_server_port)),
             keypair: cfg.keypair.clone(),
             max_concurrent_rpcs: cfg.replica_api_max_concurrent_rpcs,
         };
 
         let coordinator_api_server_config = irn_rpc::server::Config {
+            name: "coordinator_api",
             addr: socketaddr_to_multiaddr((cfg.server_addr, cfg.coordinator_api_server_port)),
             keypair: cfg.keypair.clone(),
             max_concurrent_rpcs: cfg.coordinator_api_max_concurrent_rpcs,


### PR DESCRIPTION
# Description

- limits quic inbound stream concurrency manually

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
