### PR TITLE
fix(rpc): make sure that QUIC stream permit isn't dropped early

### DIFF
--- a/crates/rpc/src/quic/server.rs
+++ b/crates/rpc/src/quic/server.rs
@@ -138,18 +138,36 @@ where
     }
 
     async fn acquire_stream_permit(&self) -> Option<OwnedSemaphorePermit> {
+        let permit = self.stream_concurrency_limiter.clone().try_acquire_owned();
+        self.meter_available_permits();
+
+        if let Ok(permit) = permit {
+            return Some(permit);
+        } else {
+            self.meter_throttled_stream();
+        }
+
         self.stream_concurrency_limiter
             .clone()
             .acquire_owned()
             .await
-            .tap_ok(|_| {
-                metrics::gauge!("quic_server_stream_concurrency_available_permits",
-                    StringLabel<"server_name"> => self.server_name
-                )
-                .set(self.stream_concurrency_limiter.available_permits() as f64)
-            })
+            .tap_ok(|_| self.meter_available_permits())
             .map_err(|_| tracing::warn!("Semaphore closed"))
             .ok()
+    }
+
+    fn meter_available_permits(&self) {
+        metrics::gauge!("quic_server_stream_concurrency_available_permits",
+            StringLabel<"server_name"> => self.server_name
+        )
+        .set(self.stream_concurrency_limiter.available_permits() as f64)
+    }
+
+    fn meter_throttled_stream(&self) {
+        metrics::counter!("quic_server_throttled_streams",
+            StringLabel<"server_name"> => self.server_name
+        )
+        .increment(1)
     }
 }
 


### PR DESCRIPTION
# Description

I have a suspicion that the unused permit  may be optimized away by the compiler.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
