### PR TITLE
feat(rpc): internal errors, part 2

### DIFF
--- a/crates/admin_api/src/client.rs
+++ b/crates/admin_api/src/client.rs
@@ -162,7 +162,7 @@ impl<A> From<irn_rpc::client::Error> for Error<A> {
 
         let rpc_err = match err {
             irn_rpc::client::Error::Transport(err) => return Self::Transport(err.to_string()),
-            irn_rpc::client::Error::Rpc(err) => err,
+            irn_rpc::client::Error::Rpc { error, .. } => error,
         };
 
         match rpc_err.code.as_ref() {

--- a/crates/irn_api/src/client.rs
+++ b/crates/irn_api/src/client.rs
@@ -537,9 +537,9 @@ impl<K: Kind> Client<K> {
 
                 loop {
                     match rx.recv_message().await {
-                        Ok(msg) => yield msg,
-                        Err(err) => {
-                            tracing::warn!(?err, "Failed to receive pubsub message, resubscribing...");
+                        Ok(Ok(msg)) => yield msg,
+                        res @ (Err(_) | Ok(Err(_))) => {
+                            tracing::warn!(?res, "Failed to receive pubsub message, resubscribing...");
                             metrics::counter!("irn_api_client_subscription_failures", "client_tag" => K::METRICS_TAG).increment(1);
                             break;
                         }
@@ -597,7 +597,7 @@ impl<K: Kind> Client<K> {
         let err = res.as_ref().err().and_then(|e| {
             Some(match e {
                 Error::RpcClient(client::Error::Transport(_)) => "transport".into(),
-                Error::RpcClient(client::Error::Rpc(err)) => err.code.clone(),
+                Error::RpcClient(client::Error::Rpc { error, .. }) => error.code.clone(),
                 Error::Api(super::Error::Unauthorized) => "unauthorized".into(),
                 Error::Api(super::Error::NotFound) => return None,
                 Error::Api(super::Error::Throttled) => "throttled".into(),

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -154,13 +154,24 @@ impl<const ID: Id, Msg: Message> Rpc for Oneshot<ID, Msg> {
 }
 
 /// RPC error.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, thiserror::Error)]
+#[error("code: {code}, description: {description:?}")]
 pub struct Error {
     /// Error code.
     pub code: Cow<'static, str>,
 
     /// Error description.
     pub description: Option<Cow<'static, str>>,
+}
+
+impl Error {
+    /// Creates a new RPC error with the provided error code.
+    pub fn new(code: &'static str) -> Self {
+        Self {
+            code: code.into(),
+            description: None,
+        }
+    }
 }
 
 /// RPC result.

--- a/crates/rpc/src/quic/mod.rs
+++ b/crates/rpc/src/quic/mod.rs
@@ -22,6 +22,8 @@ pub mod server;
 #[allow(dead_code)]
 mod metrics;
 
+const PROTOCOL_VERSION: u32 = 0;
+
 #[derive(Clone, Debug, thiserror::Error, Eq, PartialEq)]
 #[error("{0}: invalid QUIC Multiaddr")]
 pub struct InvalidMultiaddrError(Multiaddr);

--- a/crates/rpc/src/test.rs
+++ b/crates/rpc/src/test.rs
@@ -150,7 +150,7 @@ async fn suite() {
             StreamingRpc::send(client, to, |mut tx, mut rx| async move {
                 for _ in 0..3 {
                     tx.send("ping".to_string()).await?;
-                    assert_eq!(rx.recv_message().await?, "pong".to_string());
+                    assert_eq!(rx.recv_message().await?, Ok("pong".to_string()));
                 }
                 Ok(())
             })

--- a/src/network.rs
+++ b/src/network.rs
@@ -17,7 +17,7 @@ use {
     derive_more::AsRef,
     futures::{
         future,
-        stream::{self, Map, Peekable},
+        stream::{self, Map},
         Future,
         FutureExt,
         SinkExt,
@@ -53,7 +53,6 @@ use {
         collections::{HashMap, HashSet},
         fmt::{self, Debug},
         io,
-        pin::Pin,
         sync::{Arc, RwLock},
         time::Duration,
     },
@@ -766,8 +765,8 @@ pub enum PullDataError {
 
 impl irn::migration::Network<cluster::Node> for Network {
     type DataStream = Map<
-        Peekable<RecvStream<rpc::migration::PullDataResponse>>,
-        fn(io::Result<rpc::migration::PullDataResponse>) -> io::Result<ExportItem>,
+        RecvStream<irn_rpc::Result<rpc::migration::PullDataResponse>>,
+        fn(io::Result<irn_rpc::Result<rpc::migration::PullDataResponse>>) -> io::Result<ExportItem>,
     >;
 
     fn pull_keyrange(
@@ -786,36 +785,22 @@ impl irn::migration::Network<cluster::Node> for Network {
                 })
                 .await?;
 
-                let mut rx = rx.peekable();
-
-                // if the first response message is an error, return the error
-                let err_item = Pin::new(&mut rx)
-                    .next_if(|item| matches!(item, Err(_) | Ok(Err(_))))
-                    .await;
-                if let Some(item) = err_item {
-                    if let Err(e) = item? {
-                        return Ok(Err(e));
-                    }
-                };
-
-                // flatten error by converting the inner one into the outer `io::Error`
+                // flatten error by converting the inner ones into the outer `io::Error`
                 let map_fn = |res| match res {
-                    Ok(Ok(item)) => Ok(item),
-                    Ok(Err(e)) => Err(io::Error::other(irn::migration::PullKeyrangeError::from(e))),
-                    Err(e) => Err(e),
+                    Ok(Ok(Ok(item))) => Ok(item),
+                    Ok(Ok(Err(err))) => Err(io::Error::other(
+                        irn::migration::PullKeyrangeError::from(err),
+                    )),
+                    Ok(Err(err)) => Err(io::Error::other(err)),
+                    Err(err) => Err(err),
                 };
                 let rx = rx.map(map_fn as fn(_) -> _);
 
-                Ok(Ok(rx))
+                Ok(rx)
             },
         );
 
-        async move {
-            rpc_fut
-                .await
-                .map_err(|e| AnyError::new(&e))?
-                .map_err(|e| AnyError::new(&e))
-        }
+        async move { rpc_fut.await.map_err(|e| AnyError::new(&e)) }
     }
 }
 


### PR DESCRIPTION
# Description

Updates RPC client to protocol version 0, by supporting internal rpc errors returned by the server.

## How Has This Been Tested?

Existing tests.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
