### PR TITLE
fix: support extra load with shadowng client

### DIFF
--- a/crates/irn_api/src/client.rs
+++ b/crates/irn_api/src/client.rs
@@ -137,7 +137,7 @@ impl Client {
             let mut cfg = cfg.clone();
             cfg.nodes = std::mem::take(&mut cfg.shadowing_nodes);
 
-            let max_hash = (u64::MAX as f64 * factor) as u64;
+            let max_hash = (u64::MAX as f64 * factor.fract()) as u64;
             Some(Client::new_inner(cfg, kind::Shadowing {
                 extra_requests,
                 max_hash,


### PR DESCRIPTION
# Description

This adds support for the IRN shadowing client to provide extra load for stress testing. E.g. specifying shadowing factor of `2.5` would perform at least 2 shadowing requests, with a 50% chance of doing 3 requests.

## How Has This Been Tested?

Untested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
