### PR TITLE
chore: run resource intensive tasks on bigger action runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,7 @@ env:
 jobs:
   tests:
     name: "${{ matrix.cargo.name }}"
-    runs-on: 
+    runs-on:
       group: ubuntu-runners
     strategy:
       fail-fast: false


### PR DESCRIPTION
# Description

Changes some tasks so they run on the ubuntu-runners group

Resolves # (issue)

## How Has This Been Tested?

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
