### PR TITLE
fix: hscan cursor

### DIFF
--- a/crates/core/src/cluster/keyspace.rs
+++ b/crates/core/src/cluster/keyspace.rs
@@ -253,7 +253,7 @@ pub struct ReplicationStrategy<'a, S, N: Node> {
     nodes: &'a Nodes<N>,
 }
 
-impl<'a, S, N> sharding::ReplicationStrategy<node::Idx> for ReplicationStrategy<'a, S, N>
+impl<S, N> sharding::ReplicationStrategy<node::Idx> for ReplicationStrategy<'_, S, N>
 where
     S: sharding::ReplicationStrategy<N>,
     N: Node,

--- a/crates/rocks/src/db/types/common/iterators.rs
+++ b/crates/rocks/src/db/types/common/iterators.rs
@@ -99,6 +99,7 @@ where
         }
     }
 
+    #[allow(clippy::type_complexity)]
     pub fn entries(
         self,
     ) -> impl Iterator<Item = Result<(C::KeyType, C::SubKeyType, C::ValueType), Error>> + 'a {
@@ -124,7 +125,7 @@ where
     }
 }
 
-impl<'a, C> Iterator for KeyValueIterator<'a, C>
+impl<C> Iterator for KeyValueIterator<'_, C>
 where
     C: cf::Column,
 {

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -203,6 +203,7 @@ pub struct Error {
 }
 
 impl Error {
+    #[cfg(feature = "server")]
     const THROTTLED: Self = Self::new(error_code::THROTTLED);
 
     /// Creates a new RPC error with the provided error code.

--- a/crates/rpc/src/server/mod.rs
+++ b/crates/rpc/src/server/mod.rs
@@ -67,7 +67,7 @@ pub trait Server: Clone + Send + Sync + 'static {
         id: RpcId,
         stream: BiDirectionalStream,
         conn_info: &'a ClientConnectionInfo<Self>,
-    ) -> impl Future<Output = ()> + Send + '_;
+    ) -> impl Future<Output = ()> + Send + 'a;
 }
 
 /// Into [`Server`] converter.

--- a/crates/rpc/src/test.rs
+++ b/crates/rpc/src/test.rs
@@ -62,7 +62,8 @@ impl crate::Server for Node {
                             count += 1;
                         }
 
-                        Ok(assert_eq!(count, 3))
+                        assert_eq!(count, 3);
+                        Ok(())
                     })
                     .await
                 }

--- a/crates/storage_api/src/client.rs
+++ b/crates/storage_api/src/client.rs
@@ -108,7 +108,7 @@ impl Client {
         Ok(Self { rpc: rpc_client })
     }
 
-    pub fn remote_storage<'a>(&'a self, server_addr: &'a Multiaddr) -> RemoteStorage<'_> {
+    pub fn remote_storage<'a>(&'a self, server_addr: &'a Multiaddr) -> RemoteStorage<'a> {
         RemoteStorage {
             client: self,
             server_addr,
@@ -157,7 +157,7 @@ pub struct RemoteStorage<'a> {
     expected_keyspace_version: Option<u64>,
 }
 
-impl<'a> RemoteStorage<'a> {
+impl RemoteStorage<'_> {
     fn extended_key(&self, key: Key) -> ExtendedKey {
         ExtendedKey {
             inner: key.0,

--- a/crates/storage_api/src/lib.rs
+++ b/crates/storage_api/src/lib.rs
@@ -74,6 +74,7 @@ impl Key {
         self.0
     }
 
+    #[cfg(feature = "server")]
     fn from_raw_bytes(bytes: Vec<u8>) -> Option<Self> {
         match *bytes.first()? {
             Self::KIND_SHARED => Some(Self(bytes)),
@@ -316,9 +317,11 @@ pub struct MapPage {
 }
 
 impl MapPage {
-    /// Returns cursor pointing to the next [`Page`].
+    /// Returns cursor pointing to the next [`Page`] if there is one.
     pub fn next_page_cursor(&self) -> Option<&Field> {
-        self.records.last().map(|entry| &entry.field)
+        self.has_next
+            .then(|| self.records.last().map(|entry| &entry.field))
+            .flatten()
     }
 }
 

--- a/crates/storage_api/src/server.rs
+++ b/crates/storage_api/src/server.rs
@@ -124,7 +124,7 @@ struct RpcHandler<'a, S> {
     conn_info: &'a ConnectionInfo<HandshakeData, ()>,
 }
 
-impl<'a, S: Server> RpcHandler<'a, S> {
+impl<S: Server> RpcHandler<'_, S> {
     fn prepare_key(&self, key: ExtendedKey) -> irn_rpc::Result<Key> {
         if let Some(keyspace_version) = key.keyspace_version {
             if keyspace_version != self.api_server.keyspace_version() {

--- a/justfile
+++ b/justfile
@@ -127,24 +127,6 @@ fmt:
     echo '    ^^^^^^ To install `rustup component add rustfmt`, see https://github.com/rust-lang/rustfmt for details'
   fi
 
-  if command -v terraform -version >/dev/null; then
-    echo '==> Running terraform fmt'
-    terraform -chdir=terraform fmt -recursive
-  else
-    echo '==> terraform not found in PATH, skipping'
-    echo '    ^^^^^^^^^ To install see https://developer.hashicorp.com/terraform/downloads'
-  fi
-
-  if command -v jsonnetfmt -v >/dev/null; then
-    echo '==> Running jsonnetfmt'
-    for file in `find terraform -name "*.libsonnet" -type f`; do
-      jsonnetfmt -i "${file}"
-    done
-  else
-    echo '==> jsonnetfmt not found in PATH, skipping'
-    echo '    ^^^^^^^^^^ To install see https://github.com/google/jsonnet/'
-  fi
-
 # Run commit checker
 commit-check:
   #!/bin/bash

--- a/src/consensus/mod.rs
+++ b/src/consensus/mod.rs
@@ -304,7 +304,7 @@ impl Consensus {
                     cfg.known_peers
                         .get(&id)
                         .map(|addr| (NodeId(id), Node(addr.clone())))
-                        .ok_or_else(|| InitializationError::BootstrapNodeAddrMissing(id))
+                        .ok_or(InitializationError::BootstrapNodeAddrMissing(id))
                 };
 
                 nodes.into_iter().map(map_fn).collect::<Result<_, _>>()

--- a/src/network.rs
+++ b/src/network.rs
@@ -1067,7 +1067,7 @@ pub struct RemoteNode<'a> {
     pub client: Client,
 }
 
-impl<'a> RemoteNode<'a> {
+impl RemoteNode<'_> {
     pub fn into_owned(self) -> RemoteNode<'static> {
         RemoteNode {
             id: Cow::Owned(self.id.into_owned()),
@@ -1077,7 +1077,7 @@ impl<'a> RemoteNode<'a> {
     }
 }
 
-impl<'a> RemoteNode<'a> {
+impl RemoteNode<'_> {
     pub fn id(&self) -> PeerId {
         self.id.clone().into_owned()
     }


### PR DESCRIPTION
# Description

This fixes an issue where the data page returned from `hscan` would incorrectly return a cursor to next page when it shouldn't.

Also addresses some nightly clippy complaints.

## How Has This Been Tested?

Untested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
