### PR TITLE
fix: configure client api throttling

### DIFF
--- a/crates/client_api/src/server.rs
+++ b/crates/client_api/src/server.rs
@@ -39,6 +39,10 @@ pub struct Config {
     pub network_id: String,
 
     pub cluster_view: domain::ClusterView,
+
+    pub max_concurrent_connections: u32,
+
+    pub max_concurrent_streams: u32,
 }
 
 /// API server.
@@ -68,9 +72,8 @@ pub trait Server: Clone + Send + Sync + 'static {
             name: const { crate::RPC_SERVER_NAME.as_str() },
             addr: cfg.addr,
             keypair: cfg.keypair.clone(),
-            // TODO: Make these configurable or find good defaults.
-            max_concurrent_connections: 500,
-            max_concurrent_streams: 100,
+            max_concurrent_connections: cfg.max_concurrent_connections,
+            max_concurrent_streams: cfg.max_concurrent_streams,
         };
 
         let inner = Arc::new(Inner {

--- a/crates/rocks/src/db/types/common/iterators.rs
+++ b/crates/rocks/src/db/types/common/iterators.rs
@@ -149,7 +149,7 @@ fn parse_kv<C: cf::Column>(
 
 #[inline]
 fn parse_key<C: cf::Column>((key, _): &KVBytes) -> Result<(C::KeyType, C::SubKeyType), Error> {
-    C::parse_ext_key(key).map_err(Into::into)
+    C::parse_ext_key(key)
 }
 
 #[inline]

--- a/crates/rpc/src/client/mod.rs
+++ b/crates/rpc/src/client/mod.rs
@@ -75,7 +75,7 @@ pub trait Client<A: Sync = Multiaddr>: Send + Sync {
         async move {
             self.send_rpc(addr, RPC::ID, &move |stream| async move {
                 let (rx, tx) = stream.upgrade::<RpcResult<RPC>, RPC::Request>();
-                f(tx, rx).await.map_err(Into::into)
+                f(tx, rx).await
             })
             .force_send_impl()
             .await

--- a/crates/rpc/src/quic/client.rs
+++ b/crates/rpc/src/quic/client.rs
@@ -379,7 +379,6 @@ impl<H: Handshake> Client<H> {
             .with_timeout(Duration::from_secs(5))
             .await
             .map_err(|_| ConnectionHandlerError::ConnectionTimeout)?
-            .map_err(Into::into)
     }
 
     /// Establishes a [`BiDirectionalStream`] with one of the remote peers.

--- a/crates/wcn/src/commands/node/start.rs
+++ b/crates/wcn/src/commands/node/start.rs
@@ -184,6 +184,8 @@ pub async fn exec(args: StartCmd) -> anyhow::Result<()> {
         metrics_server_port: config.server.metrics_port,
         coordinator_api_max_concurrent_connections: 500,
         coordinator_api_max_concurrent_rpcs: 4500,
+        client_api_max_concurrent_connections: 500,
+        client_api_max_concurrent_rpcs: 2000,
         replica_api_max_concurrent_connections: 500,
         replica_api_max_concurrent_rpcs: 4500,
         is_raft_voter: false,

--- a/src/config.rs
+++ b/src/config.rs
@@ -43,6 +43,12 @@ pub struct Config {
     /// Port of the Prometheus metrics server.
     pub metrics_server_port: u16,
 
+    /// Maximum number of concurrent Client API connections.
+    pub client_api_max_concurrent_connections: u32,
+
+    /// Maximum number of concurrent Client API RPCs.
+    pub client_api_max_concurrent_rpcs: u32,
+
     /// Maximum number of concurrent Replica API connections.
     pub replica_api_max_concurrent_connections: u32,
 
@@ -155,6 +161,10 @@ impl Config {
             client_api_server_port: raw.client_api_server_port.unwrap_or(3014),
             admin_api_server_port: raw.admin_api_server_port.unwrap_or(3013),
             metrics_server_port: raw.metrics_server_port.unwrap_or(3014),
+            client_api_max_concurrent_connections: raw
+                .client_api_max_concurrent_connections
+                .unwrap_or(500),
+            client_api_max_concurrent_rpcs: raw.client_api_max_concurrent_rpcs.unwrap_or(2000),
             replica_api_max_concurrent_connections: raw
                 .replica_api_max_concurrent_connections
                 .unwrap_or(500),
@@ -228,6 +238,8 @@ struct RawConfig {
     admin_api_server_port: Option<u16>,
     metrics_server_port: Option<u16>,
 
+    client_api_max_concurrent_connections: Option<u32>,
+    client_api_max_concurrent_rpcs: Option<u32>,
     replica_api_max_concurrent_connections: Option<u32>,
     replica_api_max_concurrent_rpcs: Option<u32>,
     coordinator_api_max_concurrent_connections: Option<u32>,

--- a/src/consensus/mod.rs
+++ b/src/consensus/mod.rs
@@ -68,28 +68,19 @@ impl raft::State<TypeConfig> for State {
             raft::LogEntryPayload::Normal(change) => match change {
                 Change::AddNode(c) => self
                     .cluster
-                    .modify(|cluster| cluster.add_node(c.node.clone()).map(|()| true))
-                    .map_err(Into::into),
-
+                    .modify(|cluster| cluster.add_node(c.node.clone()).map(|()| true)),
                 Change::CompletePull(c) => self
                     .cluster
-                    .modify(|cluster| cluster.complete_pull(&c.node_id, c.keyspace_version))
-                    .map_err(Into::into),
-
-                Change::ShutdownNode(c) => self
-                    .cluster
-                    .modify(|cluster| cluster.shutdown_node(&c.id))
-                    .map_err(Into::into),
-
+                    .modify(|cluster| cluster.complete_pull(&c.node_id, c.keyspace_version)),
+                Change::ShutdownNode(c) => {
+                    self.cluster.modify(|cluster| cluster.shutdown_node(&c.id))
+                }
                 Change::StartupNode(c) => self
                     .cluster
-                    .modify(|cluster| cluster.startup_node(c.node.clone()).map(|()| true))
-                    .map_err(Into::into),
-
+                    .modify(|cluster| cluster.startup_node(c.node.clone()).map(|()| true)),
                 Change::DecommissionNode(c) => self
                     .cluster
-                    .modify(|cluster| cluster.decommission_node(&c.id).map(|()| true))
-                    .map_err(Into::into),
+                    .modify(|cluster| cluster.decommission_node(&c.id).map(|()| true)),
             },
             raft::LogEntryPayload::Membership(membership) => {
                 self.membership = StoredMembership::new(Some(entry.log_id), membership.clone());

--- a/src/network.rs
+++ b/src/network.rs
@@ -993,6 +993,8 @@ impl Network {
             authorized_clients: cfg.authorized_clients.clone(),
             network_id: cfg.network_id.clone(),
             cluster_view: node.consensus().cluster_view().clone(),
+            max_concurrent_connections: cfg.client_api_max_concurrent_connections,
+            max_concurrent_streams: cfg.client_api_max_concurrent_rpcs,
         };
 
         let client_api_server = ClientApiServer {
@@ -1110,9 +1112,9 @@ impl Pubsub {
     fn publish(&self, evt: rpc::broadcast::PubsubEventPayload) {
         // `Err` can't happen here, if the lock is poisoned then we have already crashed
         // as we don't handle panics.
-        let subscribers = self.inner.read().unwrap().subscribers.clone();
+        let inner = self.inner.read().unwrap();
 
-        for sub in subscribers.values() {
+        for sub in inner.subscribers.values() {
             if sub.channels.contains(&evt.channel) {
                 match sub.tx.try_send(evt.clone()) {
                     Ok(_) => {}

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -38,5 +38,5 @@ pub fn decommission(pid: i32) -> anyhow::Result<()> {
 }
 
 fn listener(kind: SignalKind) -> anyhow::Result<Signal> {
-    unix::signal(kind).context("Failed to initialize {kind:?} listener")
+    unix::signal(kind).context("Failed to initialize listener")
 }


### PR DESCRIPTION
# Description

This adds configuration variables for the client API throttling params, and sets the number of connections to `500` and the number of concurrent RPCs to `2000` by default.

Also, cleans up clippy problems.

## How Has This Been Tested?

Untested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
