### PR TITLE
fix: increase rocksdb callback queue capacity

### DIFF
--- a/crates/rocks/src/db/reader.rs
+++ b/crates/rocks/src/db/reader.rs
@@ -14,7 +14,7 @@ use {
     tokio::sync::oneshot,
 };
 
-const CHANNEL_CAPACITY: usize = 1024;
+const CHANNEL_CAPACITY: usize = 8192;
 
 #[derive(Debug, thiserror::Error)]
 #[error("Invalid number of reader threads")]


### PR DESCRIPTION
# Description

This increases the rocksdb callback queue capacity by 8x to shift the errors we're getting from rocksdb to RPC throttling at node boot time.

## How Has This Been Tested?

Untested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
