### PR TITLE
feat(rpc): pluggable transport

### DIFF
--- a/crates/rpc/src/tcp/mod.rs
+++ b/crates/rpc/src/tcp/mod.rs
@@ -46,10 +46,6 @@ fn try_multiaddr_to_socketaddr(addr: &Multiaddr) -> Option<SocketAddr> {
     Some(match (proto1, proto2) {
         (Protocol::Ip4(ip), Protocol::Tcp(port)) => SocketAddr::new(ip.into(), port),
         (Protocol::Ip6(ip), Protocol::Tcp(port)) => SocketAddr::new(ip.into(), port),
-
-        // TODO: Remove. Temporary
-        (Protocol::Ip4(ip), Protocol::Udp(port)) => SocketAddr::new(ip.into(), port),
-        (Protocol::Ip6(ip), Protocol::Udp(port)) => SocketAddr::new(ip.into(), port),
         _ => return None,
     })
 }


### PR DESCRIPTION
# Description

- makes rpc machinery generic over transport
- implements TCP transport
- spawns Storage API TCP server alongside the QUIC one

## How Has This Been Tested?

- new unit tests
- integration tests via temporary switching the transport to TCP

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
