### PR TITLE
fix: cleanup legacy hscan code

### DIFF
--- a/crates/rocks/src/db/types/common/iterators.rs
+++ b/crates/rocks/src/db/types/common/iterators.rs
@@ -162,35 +162,6 @@ fn parse_value<C: cf::Column>((_, value): &KVBytes) -> Result<Option<C::ValueTyp
     deserialize::<DataContext<C::ValueType>>(value).map(DataContext::into_payload)
 }
 
-// TODO: Remove after migrating to the new API.
-pub struct MapRecordsGeneric;
-
-impl<C> IterTransform<C> for MapRecordsGeneric
-where
-    C: cf::Column,
-{
-    type Value = map::Record<GenericCursor, C::ValueType>;
-
-    fn map(data: &KVBytes) -> Result<Option<Self::Value>, Error> {
-        let subkey_slice = C::split_ext_key(&data.0)?;
-
-        let data = deserialize::<DataContext<C::ValueType>>(&data.1)?;
-
-        let exp = data.expiration_timestamp();
-
-        let version = data
-            .modification_timestamp()
-            .unwrap_or_else(|| data.creation_timestamp());
-
-        Ok(data.into_payload().map(|value| map::Record {
-            field: subkey_slice.to_vec(),
-            value,
-            expiration: exp,
-            version,
-        }))
-    }
-}
-
 pub struct MapRecords;
 
 impl<C> IterTransform<C> for MapRecords
@@ -240,61 +211,7 @@ pub trait IterTransform<C: cf::Column> {
     fn map(data: &KVBytes) -> Result<Option<Self::Value>, Error>;
 }
 
-// TODO: Remove after migrating to the new API.
 pub fn scan<C, T, V>(
-    backend: &RocksBackend,
-    key: &C::KeyType,
-    opts: ScanOptions<GenericCursor>,
-) -> Result<ScanResult<GenericCursor, V>, Error>
-where
-    C: cf::Column,
-    T: IterTransform<C, Value = map::Record<GenericCursor, V>>,
-{
-    let iter = if let Some(cursor) = &opts.cursor {
-        // If we have a cursor, use a different version of the iterator, which skips to
-        // the first key.
-        let key = C::ext_key_from_slice(key, cursor)?;
-        backend.prefix_iterator_with_cursor::<C, _>(key)
-    } else {
-        // If we don't have a cursor, use the regular prefix iterator.
-        let key = C::storage_key(key)?;
-        backend.prefix_iterator::<C, _>(key)
-    };
-
-    let mut iter = KeyValueIterator::<C>::new(iter)
-        .map_ok(|data| T::map(&data))
-        .flatten()
-        .filter_map(Result::transpose)
-        .peekable();
-
-    let mut result = ScanResult::with_capacity(opts.count);
-
-    // The start cursor points to the last item returned by the previous scan. So we
-    // should skip if it's the same item. But if it was removed, the iterator will
-    // start from the next item.
-    let is_same_cursor = matches!(
-        (iter.peek(), &opts.cursor),
-        (Some(Ok(rec)), Some(start_cursor)) if &rec.field == start_cursor
-    );
-
-    if is_same_cursor {
-        // Skip the same item we've returned in the previous scan.
-        iter.next();
-    }
-
-    while let Some(item) = iter.next() {
-        result.items.push(item?);
-
-        if result.items.len() >= opts.count {
-            result.has_more = iter.next().is_some();
-            break;
-        }
-    }
-
-    Ok(result)
-}
-
-pub fn scan_v2<C, T, V>(
     backend: &RocksBackend,
     key: &C::KeyType,
     opts: ScanOptions<C::SubKeyType>,

--- a/crates/storage_api/src/client.rs
+++ b/crates/storage_api/src/client.rs
@@ -338,7 +338,7 @@ impl RemoteStorage<'_> {
     /// Returns a [`MapPage`] by iterating over the [`Field`]s of the map with
     /// the provided [`Key`].
     pub async fn hscan(self, key: Key, count: u32, cursor: Option<Field>) -> Result<MapPage> {
-        let resp = HScanV2::send(self.rpc_client(), self.server_addr, &HScanRequest {
+        let resp = HScan::send(self.rpc_client(), self.server_addr, &HScanRequest {
             key: self.extended_key(key),
             count,
             cursor,

--- a/crates/storage_api/src/lib.rs
+++ b/crates/storage_api/src/lib.rs
@@ -471,10 +471,9 @@ struct HCardResponse {
     cardinality: u64,
 }
 
-// TODO: Remove after migrating to the new API.
 type HScan = rpc::Unary<{ rpc::id(b"hscan") }, HScanRequest, HScanResponse>;
 
-// This is the fixed version of `hscan` that properly deserializes fields.
+// TODO: Remove when clients are no longer using it.
 type HScanV2 = rpc::Unary<{ rpc::id(b"hscan_v2") }, HScanRequest, HScanResponse>;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/storage_api/src/server.rs
+++ b/crates/storage_api/src/server.rs
@@ -99,14 +99,6 @@ pub trait Server: Clone + Send + Sync + 'static {
         cursor: Option<Field>,
     ) -> impl Future<Output = Result<MapPage>> + Send;
 
-    // TODO: Remove after migrating to the new API.
-    fn hscan_v2(
-        &self,
-        key: Key,
-        count: u32,
-        cursor: Option<Field>,
-    ) -> impl Future<Output = Result<MapPage>> + Send;
-
     /// Converts this Storage API [`Server`] into an [`rpc::Server`].
     fn into_rpc_server(self, cfg: Config<impl Authenticator>) -> impl rpc::Server {
         let timeouts = Timeouts::new().with_default(cfg.operation_timeout);
@@ -308,29 +300,6 @@ impl<S: Server> RpcHandler<'_, S> {
             has_more: page.has_next,
         })
     }
-
-    // TODO: Remove after migrating to the new API.
-    async fn hscan_v2(&self, req: HScanRequest) -> wcn_rpc::Result<HScanResponse> {
-        let page = self
-            .api_server
-            .hscan_v2(self.prepare_key(req.key)?, req.count, req.cursor)
-            .await
-            .map_err(Error::into_rpc_error)?;
-
-        Ok(HScanResponse {
-            records: page
-                .records
-                .into_iter()
-                .map(|rec| HScanResponseRecord {
-                    field: rec.field,
-                    value: rec.value,
-                    expiration: rec.expiration.timestamp(),
-                    version: rec.version.timestamp(),
-                })
-                .collect(),
-            has_more: page.has_next,
-        })
-    }
 }
 
 #[derive(Clone, Debug)]
@@ -378,7 +347,7 @@ where
                 HSetExp::ID => HSetExp::handle(stream, |req| handler.hset_exp(req)).await,
                 HCard::ID => HCard::handle(stream, |req| handler.hcard(req)).await,
                 HScan::ID => HScan::handle(stream, |req| handler.hscan(req)).await,
-                HScanV2::ID => HScanV2::handle(stream, |req| handler.hscan_v2(req)).await,
+                HScanV2::ID => HScanV2::handle(stream, |req| handler.hscan(req)).await,
 
                 id => return tracing::warn!("Unexpected RPC: {}", rpc::Name::new(id)),
             }

--- a/src/network.rs
+++ b/src/network.rs
@@ -405,36 +405,6 @@ impl storage_api::Server for StorageApiServer {
             })
             .map_err(storage_api::server::Error::new)
     }
-
-    // TODO: Remove after migrating to the new API.
-    fn hscan_v2(
-        &self,
-        key: storage_api::Key,
-        count: u32,
-        cursor: Option<storage_api::Field>,
-    ) -> impl Future<Output = storage_api::server::Result<storage_api::MapPage>> + Send {
-        let key = generic_key(key);
-        let opts = ScanOptions::new(count as usize).with_cursor(cursor);
-
-        async move { self.map_storage().hscan_v2(&key, opts).await }
-            .with_metrics(future_metrics!("storage_operation", "op_name" => "hscan"))
-            .map_ok(|res| storage_api::MapPage {
-                records: res
-                    .items
-                    .into_iter()
-                    .map(|rec| storage_api::MapRecord {
-                        field: rec.field,
-                        value: rec.value,
-                        expiration: storage_api::EntryExpiration::from_unix_timestamp_secs(
-                            rec.expiration,
-                        ),
-                        version: storage_api::EntryVersion::from_unix_timestamp_micros(rec.version),
-                    })
-                    .collect(),
-                has_next: res.has_more,
-            })
-            .map_err(storage_api::server::Error::new)
-    }
 }
 
 impl ReplicaApiServer {


### PR DESCRIPTION
# Description

Cleans up the legacy `hscan` server implementation as a follow-up to https://github.com/WalletConnectFoundation/wcn/pull/157. Now both `hscan` and `hscan_v2` RPCs use the same handlers and return the same data. Once all of the clients have been updated to this version, we can remove `HScanV2` RPC method completing the migration.

This should be merged and deployed after the [blockchain API update](https://github.com/reown-com/blockchain-api/pull/944) is in prod.

Remaining migration steps:
- Deploy this code server-side;
- Update clients;
- Remove `HScanV2` RPC handler in a follow-up PR.

## How Has This Been Tested?

Existing tests.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
