### PR TITLE
fix(rpc): remove protocol version downgrade

### DIFF
--- a/crates/rpc/src/quic/server.rs
+++ b/crates/rpc/src/quic/server.rs
@@ -132,11 +132,10 @@ where
                 .await
                 .map_err(|_| ConnectionError::Timeout)??;
 
-            // TODO: Error on timeout, instead of downgrading the protocol version
             let header = read_connection_header(&conn)
                 .with_timeout(Duration::from_millis(500))
                 .await
-                .unwrap_or_else(|_| Ok(super::ConnectionHeader::default()))?;
+                .map_err(|_| ConnectionError::ReadHeaderTimeout)??;
 
             let _conn_permit = conn_permit;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@ pub fn exec() -> anyhow::Result<()> {
 
     // TODO: Make this version consistent with the version in the repo, and find a
     // way to set it automatically.
-    wc::metrics::gauge!("wcn_node_version").set(240211.0);
+    wc::metrics::gauge!("wcn_node_version").set(250211.1);
 
     let cfg = Config::from_env().context("failed to parse config")?;
 


### PR DESCRIPTION
# Description

Removes the protocol version downgrade which is no longer needed.
I think it sometimes may me triggered on node restart, which breaks server multiplexing.

## How Has This Been Tested?

Existing tests

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
