### PR TITLE
fix: upgrade rocksdb

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,6 +73,9 @@ jobs:
           profile: default
           override: true
 
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y liburing-dev pkg-config llvm clang libclang1 libclang-dev build-essential
+
       - uses: Swatinem/rust-cache@v2
 
       - uses: taiki-e/install-action@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -990,17 +990,16 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.65.1"
+version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfdf7b466f9a4903edc73f95d6d2bcd5baf8ae620638762244d3f60143643cc5"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
+ "itertools 0.10.5",
  "lazy_static",
  "lazycell",
- "peeking_take_while",
- "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
@@ -1229,12 +1228,13 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.90"
+version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
  "jobserver",
  "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -1314,7 +1314,6 @@ checksum = "67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1"
 dependencies = [
  "glob",
  "libc",
- "libloading",
 ]
 
 [[package]]
@@ -3487,9 +3486,9 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jobserver"
-version = "0.1.28"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
  "libc",
 ]
@@ -3574,16 +3573,6 @@ name = "libc"
 version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
-
-[[package]]
-name = "libloading"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
-dependencies = [
- "cfg-if",
- "windows-targets 0.52.4",
-]
 
 [[package]]
 name = "libm"
@@ -3792,14 +3781,12 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.11.0+8.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3386f101bcb4bd252d8e9d2fb41ec3b0862a15a62b478c355b2982efa469e3e"
+version = "0.17.2+9.10.0"
+source = "git+https://github.com/WalletConnect/rust-rocksdb.git?rev=753bfd0#753bfd032acf75ca1b445519c8ec2fc088ca5e05"
 dependencies = [
  "bindgen",
  "bzip2-sys",
  "cc",
- "glob",
  "libc",
  "libz-sys",
  "lz4-sys",
@@ -3861,9 +3848,9 @@ dependencies = [
 
 [[package]]
 name = "lz4-sys"
-version = "1.9.4"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d27b317e207b10f69f5e75494119e391a96f48861ae870d1da6edac98ca900"
+checksum = "109de74d5d2353660401699a4174a4ff23fcc649caf553df71933c7fb45ad868"
 dependencies = [
  "cc",
  "libc",
@@ -4441,12 +4428,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
-
-[[package]]
 name = "pem"
 version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4602,16 +4583,6 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
-
-[[package]]
-name = "prettyplease"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d3928fb5db768cb86f891ff014f0144589297e3c6a1aba6ed7cecfdace270c7"
-dependencies = [
- "proc-macro2",
- "syn 2.0.100",
-]
 
 [[package]]
 name = "primitive-types"
@@ -5218,9 +5189,8 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6f170a4041d50a0ce04b0d2e14916d6ca863ea2e422689a5b694395d299ffe"
+version = "0.23.0"
+source = "git+https://github.com/WalletConnect/rust-rocksdb.git?rev=753bfd0#753bfd032acf75ca1b445519c8ec2fc088ca5e05"
 dependencies = [
  "libc",
  "librocksdb-sys",

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@
 # Build args
 #
 ################################################################################
-ARG                 BASE="rust:1.79-buster"
-ARG                 RUNTIME="debian:buster-slim"
+ARG                 BASE="rust:1.84-bookworm"
+ARG                 RUNTIME="debian:bookworm-slim"
 ARG                 VERSION="unknown"
 ARG                 SHA="unknown"
 ARG                 MAINTAINER="WalletConnect"
@@ -40,7 +40,7 @@ FROM                build-${PROFILE} AS build
 ARG                 LOG_LEVEL
 ARG                 WORK_DIR
 
-RUN                 apt-get update && apt-get install -y --no-install-recommends clang
+RUN                 apt-get update && apt-get install -y --no-install-recommends clang llvm libclang1 libclang-dev liburing-dev
 
 WORKDIR             ${WORK_DIR}
 
@@ -69,9 +69,9 @@ LABEL               sha=${SHA}
 LABEL               maintainer=${MAINTAINER}
 
 RUN                 apt-get update \
-  && apt-get install -y --no-install-recommends ca-certificates libssl-dev procps linux-perf \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
+    && apt-get install -y --no-install-recommends ca-certificates libssl-dev procps linux-perf liburing-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR             ${WORK_DIR}
 

--- a/crates/rocks/Cargo.toml
+++ b/crates/rocks/Cargo.toml
@@ -23,7 +23,9 @@ async-trait = "0.1"
 async-stream = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
-rocksdb = { version = "0.21", default-features = false, features = ["lz4"] }
+rocksdb = { git = "https://github.com/WalletConnect/rust-rocksdb.git", rev = "753bfd0", default-features = false, features = [
+    "lz4",
+] }
 chrono = { version = "0.4", features = ["serde"] }
 rand = "0.8"
 futures-util = "0.3"
@@ -40,9 +42,7 @@ postcard = { version = "1.0", default-features = false, features = [
     "alloc",
     "use-std",
 ] }
-derive_more = { workspace = true, features = [
-    "from",
-] }
+derive_more = { workspace = true, features = ["from"] }
 
 [dev-dependencies]
 tokio = { version = "1", default-features = false, features = ["test-util"] }


### PR DESCRIPTION
# Description

This updates rocksdb to the latest version, plus the following commit: https://github.com/WalletConnect/rust-rocksdb/commit/4bc611928c8a46fe5695662b114c52357449009d to export cache usage metrics, which will guide us in properly configuring `HyperClockCache` (see [the docs](https://docs.rs/rocksdb/latest/rocksdb/struct.Cache.html#method.new_hyper_clock_cache)).

## How Has This Been Tested?

Existing tests.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
