### PR TITLE
fix: hscan migration cleanup

### DIFF
--- a/crates/replication/src/lib.rs
+++ b/crates/replication/src/lib.rs
@@ -1,6 +1,6 @@
 pub use {
     client_api::SubscriptionEvent,
-    storage_api::{self as storage, auth, identity, Multiaddr, PeerId},
+    storage_api::{self as storage, auth, identity, Multiaddr, PeerAddr, PeerId},
 };
 use {
     consistency::ReplicationResults,
@@ -8,7 +8,7 @@ use {
     domain::{Cluster, HASHER},
     futures::{channel::oneshot, stream::FuturesUnordered, FutureExt, Stream, StreamExt},
     std::{collections::HashSet, future::Future, hash::BuildHasher, sync::Arc, time::Duration},
-    storage_api::{client::RemoteStorage, PeerAddr},
+    storage_api::client::RemoteStorage,
     tap::{Pipe, TapFallible as _},
     wc::metrics::{
         self,

--- a/crates/storage_api/src/lib.rs
+++ b/crates/storage_api/src/lib.rs
@@ -473,9 +473,6 @@ struct HCardResponse {
 
 type HScan = rpc::Unary<{ rpc::id(b"hscan") }, HScanRequest, HScanResponse>;
 
-// TODO: Remove when clients are no longer using it.
-type HScanV2 = rpc::Unary<{ rpc::id(b"hscan_v2") }, HScanRequest, HScanResponse>;
-
 #[derive(Clone, Debug, Serialize, Deserialize)]
 struct HScanRequest {
     key: ExtendedKey,

--- a/crates/storage_api/src/server.rs
+++ b/crates/storage_api/src/server.rs
@@ -347,7 +347,6 @@ where
                 HSetExp::ID => HSetExp::handle(stream, |req| handler.hset_exp(req)).await,
                 HCard::ID => HCard::handle(stream, |req| handler.hcard(req)).await,
                 HScan::ID => HScan::handle(stream, |req| handler.hscan(req)).await,
-                HScanV2::ID => HScanV2::handle(stream, |req| handler.hscan(req)).await,
 
                 id => return tracing::warn!("Unexpected RPC: {}", rpc::Name::new(id)),
             }


### PR DESCRIPTION
# Description

**Note: Do not merge/deploy to the cluster until the relay and blockchain API clients have been migrated to this version:**
- Relay: https://github.com/reown-com/rs-relay/pull/1713;
- Blockchain API: https://github.com/reown-com/blockchain-api/pull/962.

The final step of `hscan` API migration. This cleans up the `hscan_v2` RPC, as it's no longer needed.

## How Has This Been Tested?

Existing tests.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
