### PR TITLE
fix: switch Raft snapshot to JSON

### DIFF
--- a/src/consensus/mod.rs
+++ b/src/consensus/mod.rs
@@ -115,7 +115,7 @@ impl raft::State<TypeConfig> for State {
 
         let cluster = self.cluster.view().cluster();
 
-        postcard::to_allocvec(&StateSnapshot {
+        serde_json::to_vec(&StateSnapshot {
             last_applied_log: meta.last_log_id,
             membership: meta.last_membership.clone(),
             cluster: cluster.snapshot(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@ pub fn exec() -> anyhow::Result<()> {
 
     // TODO: Make this version consistent with the version in the repo, and find a
     // way to set it automatically.
-    wc::metrics::gauge!("wcn_node_version").set(250212.0);
+    wc::metrics::gauge!("wcn_node_version").set(250220.0);
 
     let cfg = Config::from_env().context("failed to parse config")?;
 


### PR DESCRIPTION
# Description

Switches Raft snapshot serialization (network) to JSON.
Should be enough to update only WalletConnect nodes, as this only affects the leader.
Other nodes already support JSON de-serialization.

## How Has This Been Tested?

Existing tests

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
