### PR TITLE
fix: adjust liveness check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4404,7 +4404,7 @@ dependencies = [
 [[package]]
 name = "phi-accrual-failure-detector"
 version = "0.1.0"
-source = "git+https://github.com/heilhead/phi-accrual-failure-detector.git?rev=7a6b36b#7a6b36beaa31b867c90c56047807c2073cd4e20b"
+source = "git+https://github.com/heilhead/phi-accrual-failure-detector.git?rev=01e5706#01e5706e73cbb3f29fb5542a1bfb359502503a24"
 dependencies = [
  "thiserror",
 ]

--- a/crates/echo_api/Cargo.toml
+++ b/crates/echo_api/Cargo.toml
@@ -26,7 +26,7 @@ tap = "1.0"
 futures = "0.3"
 tracing = "0.1"
 chrono = "0.4"
-phi-accrual-failure-detector = { git = "https://github.com/heilhead/phi-accrual-failure-detector.git", rev = "7a6b36b" }
+phi-accrual-failure-detector = { git = "https://github.com/heilhead/phi-accrual-failure-detector.git", rev = "01e5706" }
 governor = { version = "0.8", default-features = false, features = ["std"] }
 
 [lints]


### PR DESCRIPTION
# Description

Changes:
- Remove log noise for unreachable nodes. Replaced the logs with a metrics counter `wcn_echo_client_connection_failure`;
- Moved the 'stats loop' so that it continues to update suspicion score even if connection is permanently broken;
- Updated the 'stats loop' so that it doesn't update suspicion metrics if the connection hasn't received any heartbeats, as it's impossible to calculate it in such cases.

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
