### PR TITLE
fix: enable TCP_NODELAY for echo api

### DIFF
--- a/crates/echo_api/src/server.rs
+++ b/crates/echo_api/src/server.rs
@@ -45,6 +45,10 @@ pub async fn spawn(config: Config) -> Result<(), Error> {
             continue;
         };
 
+        let _ = socket
+            .set_nodelay(true)
+            .tap_err(|err| tracing::warn!(?err, "failed to set TCP_NODELAY"));
+
         let Ok(permit) = semaphore.clone().try_acquire_owned() else {
             metrics::counter!("wcn_echo_server_connection_dropped").increment(1);
             continue;


### PR DESCRIPTION
# Description

Enable `TCP_NODELAY` for both server- and client-side echo API sockets.

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
