### PR TITLE
fix: non-linux target compilation

### DIFF
--- a/crates/rpc/src/quic/mod.rs
+++ b/crates/rpc/src/quic/mod.rs
@@ -1,10 +1,11 @@
+#[cfg(target_os = "linux")]
+use nix::sys::socket::{setsockopt, sockopt};
 use {
     crate::{
         transport::{self, Priority},
         ServerName,
     },
     libp2p::{identity::Keypair, multiaddr::Protocol, Multiaddr, PeerId},
-    nix::sys::socket::{setsockopt, sockopt},
     quinn::{crypto::rustls::QuicClientConfig, rustls::pki_types::CertificateDer, VarInt},
     std::{
         io,


### PR DESCRIPTION
# Description

Don't set socket priority on non-linux os to avoid compilation errors.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
