### PR TITLE
feat: cluster pulse monitor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4414,7 +4414,7 @@ dependencies = [
 [[package]]
 name = "phi-accrual-failure-detector"
 version = "0.1.0"
-source = "git+https://github.com/heilhead/phi-accrual-failure-detector.git?rev=01e5706#01e5706e73cbb3f29fb5542a1bfb359502503a24"
+source = "git+https://github.com/heilhead/phi-accrual-failure-detector.git?rev=30fb190#30fb190da0127fa2fa14b833d44c4e39872f81b7"
 dependencies = [
  "thiserror",
 ]
@@ -4660,6 +4660,24 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "pulse_monitor"
+version = "0.1.0"
+dependencies = [
+ "arc-swap",
+ "futures",
+ "phi-accrual-failure-detector",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "wc",
+ "wcn_domain",
+ "wcn_echo_api",
+ "wcn_rpc",
 ]
 
 [[package]]
@@ -6735,18 +6753,20 @@ name = "wcn_client_api"
 version = "0.1.0"
 dependencies = [
  "arc-swap",
+ "futures",
  "futures-util",
  "postcard",
+ "pulse_monitor",
  "rand 0.8.5",
  "serde",
  "serde_json",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tracing",
  "wc",
  "wcn_auth",
  "wcn_domain",
- "wcn_echo_api",
  "wcn_rpc",
 ]
 
@@ -6819,7 +6839,6 @@ dependencies = [
  "chrono",
  "futures",
  "governor",
- "phi-accrual-failure-detector",
  "serde",
  "tap",
  "thiserror",
@@ -6878,6 +6897,7 @@ dependencies = [
  "pin-project",
  "postcard",
  "proc-mounts",
+ "pulse_monitor",
  "raft",
  "rand 0.8.5",
  "relay_rocks",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ admin_api = { package = "wcn_admin_api", path = "crates/admin_api" }
 client_api = { package = "wcn_client_api", path = "crates/client_api" }
 migration_api = { package = "wcn_migration_api", path = "crates/migration_api" }
 echo_api = { package = "wcn_echo_api", path = "crates/echo_api" }
+pulse_monitor = { path = "crates/pulse_monitor" }
 raft = { path = "crates/raft" }
 wcn_rpc = { path = "crates/rpc" }
 relay_rocks = { path = "crates/rocks" }
@@ -86,6 +87,7 @@ admin_api = { workspace = true, features = ["server"] }
 client_api = { workspace = true, features = ["server", "client"] }
 migration_api = { workspace = true, features = ["server", "client"] }
 echo_api = { workspace = true, features = ["server", "client"] }
+pulse_monitor = { workspace = true }
 raft = { workspace = true }
 wcn_rpc = { workspace = true, features = ["server"] }
 relay_rocks = { workspace = true }

--- a/crates/client_api/Cargo.toml
+++ b/crates/client_api/Cargo.toml
@@ -16,14 +16,16 @@ wcn_rpc = { workspace = true }
 wc = { workspace = true, features = ["metrics"] }
 auth = { workspace = true }
 domain = { workspace = true }
-echo_api = { workspace = true, features = ["client"] }
+pulse_monitor = { workspace = true }
 
 serde = "1"
 serde_json = "1"
 thiserror = "1"
 tracing = "0.1"
+futures = "0.3"
 futures-util = "0.3"
 tokio = { version = "1", features = ["sync"] }
+tokio-stream = "0.1"
 postcard = { version = "1.0", default-features = false, features = [
     "alloc",
     "use-std",

--- a/crates/echo_api/Cargo.toml
+++ b/crates/echo_api/Cargo.toml
@@ -26,7 +26,6 @@ tap = "1.0"
 futures = "0.3"
 tracing = "0.1"
 chrono = "0.4"
-phi-accrual-failure-detector = { git = "https://github.com/heilhead/phi-accrual-failure-detector.git", rev = "01e5706" }
 governor = { version = "0.8", default-features = false, features = ["std"] }
 
 [lints]

--- a/crates/echo_api/src/lib.rs
+++ b/crates/echo_api/src/lib.rs
@@ -23,6 +23,12 @@ pub enum Error {
 
     #[error("Failed to send data: {0}")]
     Send(io::Error),
+
+    #[error("Too many outstanding requests")]
+    TooManyRequests,
+
+    #[error("{0}")]
+    Other(String),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/pulse_monitor/Cargo.toml
+++ b/crates/pulse_monitor/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "pulse_monitor"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+wc = { workspace = true, features = ["future", "metrics"] }
+echo_api = { package = "wcn_echo_api", path = "../echo_api", features = ["client"]}
+wcn_rpc = { workspace = true }
+domain = { workspace = true }
+thiserror = "1"
+tracing = "0.1"
+futures = "0.3"
+arc-swap = "1.7"
+phi-accrual-failure-detector = { git = "https://github.com/heilhead/phi-accrual-failure-detector.git", rev = "30fb190" }
+tokio-util = "0.7"
+tokio = { version = "1", default-features = false, features = [
+    "sync",
+    "time",
+    "io-util",
+] }
+tokio-stream = { version = "0.1", features = ["time"] }
+
+[lints]
+workspace = true

--- a/crates/pulse_monitor/src/lib.rs
+++ b/crates/pulse_monitor/src/lib.rs
@@ -1,0 +1,122 @@
+use {
+    arc_swap::ArcSwap,
+    futures::{Stream, StreamExt as _},
+    monitor::ClusterMonitor,
+    std::{collections::HashSet, sync::Arc, time::Duration},
+    tokio::sync::RwLock,
+    transport::EchoApiTransportFactory,
+    wc::metrics::{self, StringLabel},
+    wcn_rpc::PeerAddr,
+};
+
+pub mod monitor;
+pub mod transport;
+
+// Note: Requires a stream that would immediately yield the initial cluster
+// state.
+pub async fn run<C>(mut cluster_stream: C)
+where
+    C: Stream<Item = Arc<domain::Cluster>>,
+{
+    let mut cluster_stream = std::pin::pin!(cluster_stream);
+
+    let Some(cluster) = cluster_stream.next().await else {
+        tracing::warn!("cluster state stream ended unexpectedly");
+        return;
+    };
+
+    let cluster = ArcSwap::new(cluster);
+    let registry = RwLock::new(ClusterMonitor::default());
+
+    let cluster_update_fut = async {
+        let mut current_peers = HashSet::new();
+
+        loop {
+            current_peers = update_registry(
+                &mut *registry.write().await,
+                &cluster.load_full(),
+                &current_peers,
+            );
+
+            if let Some(next_cluster) = cluster_stream.next().await {
+                cluster.store(next_cluster);
+            } else {
+                break;
+            }
+        }
+    };
+
+    let metrics_update_fut = async {
+        let mut interval = tokio::time::interval(Duration::from_secs(15));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+        loop {
+            interval.tick().await;
+
+            let curr_cluster = cluster.load_full();
+            let registry = registry.read().await;
+            let nodes = registry.nodes();
+
+            for id in nodes {
+                let Some(status) = registry.status(id) else {
+                    continue;
+                };
+
+                let Some(node) = curr_cluster.node(id) else {
+                    continue;
+                };
+
+                let Ok(address) = node.addr().quic_socketaddr() else {
+                    continue;
+                };
+
+                let addr_str = address.to_string();
+                let available = status.is_monitoring && status.is_available;
+                let available = if available { 1.0 } else { 0.0 };
+
+                metrics::gauge!("wcn_pulse_monitor_availability", StringLabel<"destination"> => &addr_str)
+                    .set(available);
+
+                // Failure detector can't calculate suspicion level unless it's received at
+                // least one heartbeat.
+                if status.is_monitoring {
+                    metrics::gauge!("wcn_pulse_monitor_failure_suspicion", StringLabel<"destination"> => &addr_str)
+                        .set(status.suspicion_score);
+                    metrics::histogram!("wcn_pulse_monitor_latency", StringLabel<"destination"> => &addr_str)
+                        .record(status.latency);
+                }
+            }
+        }
+    };
+
+    tokio::join!(cluster_update_fut, metrics_update_fut);
+}
+
+fn update_registry(
+    registry: &mut ClusterMonitor,
+    cluster: &domain::Cluster,
+    current_peers: &HashSet<PeerAddr>,
+) -> HashSet<PeerAddr> {
+    let next_peers = cluster
+        .nodes()
+        .map(|node| node.addr())
+        .collect::<HashSet<_>>();
+
+    // Removed nodes.
+    for addr in current_peers.difference(&next_peers) {
+        registry.remove(&addr.id);
+    }
+
+    // Added nodes.
+    for addr in next_peers.difference(current_peers) {
+        // Echo server is currently hosted on the same address we're using for storage
+        // API, but it's TCP instead of UDP.
+        if let Ok(socketaddr) = addr.quic_socketaddr() {
+            registry.insert(addr.id, EchoApiTransportFactory(socketaddr));
+        } else {
+            tracing::warn!(?addr, "failed to parse socket address for peer");
+        }
+    }
+
+    next_peers
+}

--- a/crates/pulse_monitor/src/monitor.rs
+++ b/crates/pulse_monitor/src/monitor.rs
@@ -1,0 +1,202 @@
+use {
+    super::transport::{Transport, TransportFactory},
+    futures::StreamExt as _,
+    phi_accrual_failure_detector::{Detector, SyncDetector},
+    std::{
+        collections::{HashMap, VecDeque},
+        sync::{Arc, Mutex},
+        time::Duration,
+    },
+    tokio::sync::mpsc,
+    tokio_stream::wrappers::IntervalStream,
+    tokio_util::sync::DropGuard,
+    wc::{
+        future::{CancellationToken, FutureExt as _, StaticFutureExt as _},
+        metrics::{self, FutureExt as _, StringLabel},
+    },
+    wcn_rpc::PeerId,
+};
+
+struct Node {
+    detector: SyncDetector,
+    latency: Mutex<LatencyHistory>,
+}
+
+impl Node {
+    fn latency(&self) -> f64 {
+        // Safe unwrap, as it can't panic.
+        self.latency.lock().unwrap().mean()
+    }
+
+    fn heartbeat(&self, latency: f64) {
+        // Safe unwrap, as it can't panic.
+        self.latency.lock().unwrap().update(latency);
+        self.detector.heartbeat();
+    }
+}
+
+struct NodeWrapper {
+    node: Arc<Node>,
+    _guard: DropGuard,
+}
+
+pub struct NodeStatus {
+    pub is_monitoring: bool,
+    pub is_available: bool,
+    pub latency: f64,
+    pub suspicion_score: f64,
+}
+
+#[derive(Default)]
+pub struct ClusterMonitor {
+    nodes: HashMap<PeerId, NodeWrapper>,
+}
+
+impl ClusterMonitor {
+    pub fn insert<F>(&mut self, id: PeerId, factory: F)
+    where
+        F: TransportFactory + Send + Sync + 'static,
+    {
+        let node = Arc::new(Node {
+            detector: SyncDetector::default(),
+            latency: Mutex::new(LatencyHistory::new(5)),
+        });
+
+        let token = CancellationToken::new();
+
+        ping_loop(factory, node.clone())
+            .with_cancellation(token.clone())
+            .with_metrics(metrics::future_metrics!("wcn_echo_client_ping_loop"))
+            .spawn();
+
+        self.nodes.insert(id, NodeWrapper {
+            node,
+            _guard: token.drop_guard(),
+        });
+    }
+
+    pub fn remove(&mut self, id: &PeerId) {
+        self.nodes.remove(id);
+    }
+
+    pub fn nodes(&self) -> impl Iterator<Item = &PeerId> {
+        self.nodes.keys()
+    }
+
+    pub fn status(&self, id: &PeerId) -> Option<NodeStatus> {
+        let node = self.nodes.get(id)?;
+        let detector = &node.node.detector;
+
+        Some(NodeStatus {
+            is_monitoring: detector.is_monitoring(),
+            is_available: detector.is_available(),
+            latency: node.node.latency(),
+            suspicion_score: detector.phi(),
+        })
+    }
+}
+
+async fn ping_loop<F>(factory: F, node: Arc<Node>)
+where
+    F: TransportFactory + Send + Sync + 'static,
+{
+    let addr_str = factory.address().to_string();
+
+    loop {
+        // Retry broken connections.
+        if ping_loop_internal(&factory, &node).await.is_err() {
+            metrics::counter!("wcn_pulse_monitor_connection_failure", StringLabel<"destination"> => &addr_str).increment(1);
+        }
+
+        // Added delay before retrying connection.
+        tokio::time::sleep(Duration::from_secs(3)).await;
+    }
+}
+
+async fn ping_loop_internal<F>(
+    factory: &F,
+    node: &Node,
+) -> Result<(), <F::Transport as Transport>::Error>
+where
+    F: TransportFactory + Send + Sync + 'static,
+{
+    let transport = factory.create().await?;
+    let (shutdown_tx, mut shutdown_rx) = mpsc::channel(1);
+    let mut interval = tokio::time::interval(Duration::from_secs(1));
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    IntervalStream::new(interval)
+        .take_until(shutdown_rx.recv())
+        .for_each_concurrent(None, |_| async {
+            match transport.heartbeat().await {
+                Ok(elapsed) => {
+                    node.heartbeat(elapsed.as_secs_f64());
+                }
+
+                Err(_) => {
+                    // Shutdown on the first error.
+                    let _ = shutdown_tx.try_send(());
+                }
+            }
+        })
+        .await;
+
+    Ok(())
+}
+
+// Simple ring buffer to calculate mean latency over an arbitrary window.
+struct LatencyHistory {
+    data: VecDeque<f64>,
+    sum: f64,
+    capacity: usize,
+}
+
+impl LatencyHistory {
+    fn new(capacity: usize) -> Self {
+        Self {
+            data: VecDeque::with_capacity(capacity),
+            sum: 0.0,
+            capacity,
+        }
+    }
+
+    fn update(&mut self, latency: f64) {
+        if self.data.len() >= self.capacity {
+            if let Some(latency) = self.data.pop_front() {
+                self.sum -= latency;
+            };
+        }
+
+        self.data.push_back(latency);
+        self.sum += latency;
+    }
+
+    fn mean(&self) -> f64 {
+        if self.data.is_empty() {
+            0.0
+        } else {
+            self.sum / self.data.len() as f64
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn latency_history() {
+        let mut hist = LatencyHistory::new(3);
+        assert_eq!(hist.mean(), 0.0);
+        hist.update(1.0);
+        hist.update(2.0);
+        hist.update(3.0);
+        assert_eq!(hist.mean(), 2.0);
+        hist.update(4.0);
+        assert_eq!(hist.mean(), 3.0);
+        hist.update(5.0);
+        assert_eq!(hist.mean(), 4.0);
+        hist.update(6.0);
+        assert_eq!(hist.mean(), 5.0);
+    }
+}

--- a/crates/pulse_monitor/src/transport.rs
+++ b/crates/pulse_monitor/src/transport.rs
@@ -1,0 +1,43 @@
+use std::{future::Future, net::SocketAddr, time::Duration};
+
+pub trait TransportFactory {
+    type Transport: Transport;
+
+    fn address(&self) -> SocketAddr;
+
+    fn create(
+        &self,
+    ) -> impl Future<Output = Result<Self::Transport, <Self::Transport as Transport>::Error>> + Send;
+}
+
+pub trait Transport: Send + Sync {
+    type Error: std::error::Error;
+
+    fn heartbeat(&self) -> impl Future<Output = Result<Duration, Self::Error>> + Send;
+}
+
+pub struct EchoApiTransport(echo_api::client::Client);
+
+impl Transport for EchoApiTransport {
+    type Error = echo_api::Error;
+
+    fn heartbeat(&self) -> impl Future<Output = Result<Duration, Self::Error>> {
+        self.0.heartbeat()
+    }
+}
+
+pub struct EchoApiTransportFactory(pub SocketAddr);
+
+impl TransportFactory for EchoApiTransportFactory {
+    type Transport = EchoApiTransport;
+
+    fn address(&self) -> SocketAddr {
+        self.0
+    }
+
+    async fn create(&self) -> Result<EchoApiTransport, echo_api::Error> {
+        echo_api::client::Client::create(self.0)
+            .await
+            .map(EchoApiTransport)
+    }
+}


### PR DESCRIPTION
# Description

This implements a shared cluster pulse monitor, which is hooked up both server-side and client-side (through the client API).

## How Has This Been Tested?

Manually running the cluster and monitoring metrics.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
