### PR TITLE
feat: connection ip rate limiters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,7 +52,7 @@ dependencies = [
  "dhat",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.64",
  "tikv-jemalloc-ctl",
  "tikv-jemallocator",
  "tokio",
@@ -144,7 +144,7 @@ dependencies = [
  "alloy-transport",
  "futures",
  "futures-util",
- "thiserror",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -221,7 +221,7 @@ dependencies = [
  "alloy-primitives",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.64",
  "tracing",
 ]
 
@@ -240,7 +240,7 @@ dependencies = [
  "async-trait",
  "auto_impl",
  "futures-utils-wasm",
- "thiserror",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -287,7 +287,7 @@ dependencies = [
  "dashmap",
  "futures",
  "futures-utils-wasm",
- "lru",
+ "lru 0.12.3",
  "pin-project",
  "reqwest",
  "serde",
@@ -316,7 +316,7 @@ checksum = "8037e03c7f462a063f28daec9fda285a9a89da003c552f8637a80b9c8fd96241"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -354,7 +354,7 @@ dependencies = [
  "itertools 0.12.1",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -389,7 +389,7 @@ dependencies = [
  "auto_impl",
  "elliptic-curve",
  "k256",
- "thiserror",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -406,7 +406,7 @@ dependencies = [
  "coins-bip39",
  "k256",
  "rand 0.8.5",
- "thiserror",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -420,7 +420,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -437,7 +437,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.100",
  "syn-solidity",
  "tiny-keccak",
 ]
@@ -455,7 +455,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.55",
+ "syn 2.0.100",
  "syn-solidity",
 ]
 
@@ -492,7 +492,7 @@ dependencies = [
  "futures-utils-wasm",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.64",
  "tokio",
  "tower",
  "url",
@@ -751,7 +751,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror",
+ "thiserror 1.0.64",
  "time",
 ]
 
@@ -763,7 +763,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.100",
  "synstructure",
 ]
 
@@ -775,7 +775,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -797,7 +797,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -808,7 +808,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -849,7 +849,7 @@ checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1006,7 +1006,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.55",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1193,7 +1193,7 @@ dependencies = [
  "semver 1.0.22",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -1340,7 +1340,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1374,7 +1374,7 @@ dependencies = [
  "k256",
  "serde",
  "sha2",
- "thiserror",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -1390,7 +1390,7 @@ dependencies = [
  "pbkdf2",
  "rand 0.8.5",
  "sha2",
- "thiserror",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -1410,7 +1410,7 @@ dependencies = [
  "serde_derive",
  "sha2",
  "sha3",
- "thiserror",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -1684,7 +1684,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1729,7 +1729,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
- "hashbrown",
+ "hashbrown 0.14.3",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -1867,7 +1867,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.100",
  "unicode-xid",
 ]
 
@@ -1925,7 +1925,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1988,7 +1988,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2045,7 +2045,7 @@ checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2195,6 +2195,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2239,7 +2245,7 @@ version = "0.1.0"
 source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.14.1#bf8f50a711180afbf79b8c334c65b57886173d4b"
 dependencies = [
  "pin-project",
- "thiserror",
+ "thiserror 1.0.64",
  "tokio",
  "tokio-util",
 ]
@@ -2311,7 +2317,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2407,8 +2413,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "wasm-bindgen",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -2456,7 +2478,7 @@ dependencies = [
  "parking_lot",
  "signal-hook",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.64",
  "unicode-normalization",
 ]
 
@@ -2470,7 +2492,7 @@ dependencies = [
  "btoi",
  "gix-date",
  "itoa",
- "thiserror",
+ "thiserror 1.0.64",
  "winnow 0.5.40",
 ]
 
@@ -2480,7 +2502,7 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a371db66cbd4e13f0ed9dc4c0fea712d7276805fccc877f77e96374d317e87ae"
 dependencies = [
- "thiserror",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -2489,7 +2511,7 @@ version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45c8751169961ba7640b513c3b24af61aa962c967aaf04116734975cd5af0c52"
 dependencies = [
- "thiserror",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -2503,7 +2525,7 @@ dependencies = [
  "gix-features",
  "gix-hash",
  "memmap2",
- "thiserror",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -2522,7 +2544,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.64",
  "unicode-bom",
  "winnow 0.5.40",
 ]
@@ -2537,7 +2559,7 @@ dependencies = [
  "bstr",
  "gix-path",
  "libc",
- "thiserror",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -2548,7 +2570,7 @@ checksum = "180b130a4a41870edfbd36ce4169c7090bca70e195da783dea088dd973daa59c"
 dependencies = [
  "bstr",
  "itoa",
- "thiserror",
+ "thiserror 1.0.64",
  "time",
 ]
 
@@ -2561,7 +2583,7 @@ dependencies = [
  "bstr",
  "gix-hash",
  "gix-object",
- "thiserror",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -2576,7 +2598,7 @@ dependencies = [
  "gix-path",
  "gix-ref",
  "gix-sec",
- "thiserror",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -2593,7 +2615,7 @@ dependencies = [
  "once_cell",
  "prodash",
  "sha1_smol",
- "thiserror",
+ "thiserror 1.0.64",
  "walkdir",
 ]
 
@@ -2625,7 +2647,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93d7df7366121b5018f947a04d37f034717e113dcf9ccd85c34b58e57a74d5e"
 dependencies = [
  "faster-hex",
- "thiserror",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -2635,7 +2657,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ddf80e16f3c19ac06ce415a38b8591993d3f73aede049cb561becb5b3a8e242"
 dependencies = [
  "gix-hash",
- "hashbrown",
+ "hashbrown 0.14.3",
  "parking_lot",
 ]
 
@@ -2661,7 +2683,7 @@ dependencies = [
  "memmap2",
  "rustix",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -2672,7 +2694,7 @@ checksum = "f40a439397f1e230b54cf85d52af87e5ea44cc1e7748379785d3f6d03d802b00"
 dependencies = [
  "gix-tempfile",
  "gix-utils",
- "thiserror",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -2683,7 +2705,7 @@ checksum = "1dff438f14e67e7713ab9332f5fd18c8f20eb7eb249494f6c2bf170522224032"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2701,7 +2723,7 @@ dependencies = [
  "gix-validate",
  "itoa",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.64",
  "winnow 0.5.40",
 ]
 
@@ -2721,7 +2743,7 @@ dependencies = [
  "gix-quote",
  "parking_lot",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -2741,7 +2763,7 @@ dependencies = [
  "memmap2",
  "parking_lot",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -2754,7 +2776,7 @@ dependencies = [
  "gix-trace",
  "home",
  "once_cell",
- "thiserror",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -2765,7 +2787,7 @@ checksum = "cbff4f9b9ea3fa7a25a70ee62f545143abef624ac6aa5884344e70c8b0a1d9ff"
 dependencies = [
  "bstr",
  "gix-utils",
- "thiserror",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -2785,7 +2807,7 @@ dependencies = [
  "gix-tempfile",
  "gix-validate",
  "memmap2",
- "thiserror",
+ "thiserror 1.0.64",
  "winnow 0.5.40",
 ]
 
@@ -2800,7 +2822,7 @@ dependencies = [
  "gix-revision",
  "gix-validate",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -2816,7 +2838,7 @@ dependencies = [
  "gix-object",
  "gix-revwalk",
  "gix-trace",
- "thiserror",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -2831,7 +2853,7 @@ dependencies = [
  "gix-hashtable",
  "gix-object",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -2880,7 +2902,7 @@ dependencies = [
  "gix-object",
  "gix-revwalk",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -2893,7 +2915,7 @@ dependencies = [
  "gix-features",
  "gix-path",
  "home",
- "thiserror",
+ "thiserror 1.0.64",
  "url",
 ]
 
@@ -2914,7 +2936,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e39fc6e06044985eac19dd34d474909e517307582e462b2eb4c8fa51b6241545"
 dependencies = [
  "bstr",
- "thiserror",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -2925,20 +2947,22 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "governor"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "842dc78579ce01e6a1576ad896edc92fca002dd60c9c3746b7fc2bec6fb429d0"
+checksum = "be93b4ec2e4710b04d9264c0c7350cdd62a8c20e5e4ac732552ebb8f0debe8eb"
 dependencies = [
  "cfg-if",
  "futures-sink",
  "futures-timer",
  "futures-util",
+ "getrandom 0.3.1",
  "no-std-compat",
  "nonzero_ext",
  "parking_lot",
  "portable-atomic",
  "smallvec",
  "spinning_top",
+ "web-time",
 ]
 
 [[package]]
@@ -3008,6 +3032,17 @@ checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
  "ahash",
  "allocator-api2",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
 ]
 
 [[package]]
@@ -3331,7 +3366,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -3429,7 +3464,7 @@ dependencies = [
  "combine",
  "jni-sys",
  "log",
- "thiserror",
+ "thiserror 1.0.64",
  "walkdir",
 ]
 
@@ -3450,10 +3485,11 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -3565,7 +3601,7 @@ dependencies = [
  "multiaddr",
  "pin-project",
  "rw-stream-sink",
- "thiserror",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -3614,7 +3650,7 @@ dependencies = [
  "rw-stream-sink",
  "serde",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.64",
  "tracing",
  "unsigned-varint 0.8.0",
  "void",
@@ -3667,7 +3703,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "sha2",
- "thiserror",
+ "thiserror 1.0.64",
  "tracing",
  "zeroize",
 ]
@@ -3695,7 +3731,7 @@ dependencies = [
  "serde",
  "sha2",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.64",
  "tracing",
  "uint",
  "void",
@@ -3714,7 +3750,7 @@ dependencies = [
  "futures-timer",
  "libp2p-core",
  "libp2p-identity",
- "lru",
+ "lru 0.12.3",
  "multistream-select",
  "once_cell",
  "rand 0.8.5",
@@ -3738,7 +3774,7 @@ dependencies = [
  "ring 0.17.8",
  "rustls",
  "rustls-webpki 0.101.7",
- "thiserror",
+ "thiserror 1.0.64",
  "x509-parser",
  "yasna",
 ]
@@ -3809,7 +3845,16 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.14.3",
+]
+
+[[package]]
+name = "lru"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
+dependencies = [
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -3898,7 +3943,7 @@ dependencies = [
  "metrics",
  "metrics-util",
  "quanta",
- "thiserror",
+ "thiserror 1.0.64",
  "tokio",
  "tracing",
 ]
@@ -3911,7 +3956,7 @@ checksum = "4259040465c955f9f2f1a4a8a16dc46726169bca0f88e8fb2dbeced487c3e828"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
- "hashbrown",
+ "hashbrown 0.14.3",
  "metrics",
  "num_cpus",
  "quanta",
@@ -4184,7 +4229,7 @@ checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4241,7 +4286,7 @@ dependencies = [
  "maplit",
  "rand 0.8.5",
  "serde",
- "thiserror",
+ "thiserror 1.0.64",
  "tokio",
  "tracing",
  "tracing-futures",
@@ -4271,7 +4316,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4353,7 +4398,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa925f9becb532d758b0014b472c576869910929cf4c3f8054b386f19ab9e21"
 dependencies = [
- "thiserror",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -4407,7 +4452,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "560131c633294438da9f7c4b08189194b20946c8274c6b9e38881a7874dc8ee8"
 dependencies = [
  "memchr",
- "thiserror",
+ "thiserror 1.0.64",
  "ucd-trie",
 ]
 
@@ -4416,7 +4461,7 @@ name = "phi-accrual-failure-detector"
 version = "0.1.0"
 source = "git+https://github.com/heilhead/phi-accrual-failure-detector.git?rev=30fb190#30fb190da0127fa2fa14b833d44c4e39872f81b7"
 dependencies = [
- "thiserror",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -4447,7 +4492,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4548,7 +4593,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d3928fb5db768cb86f891ff014f0144589297e3c6a1aba6ed7cecfdace270c7"
 dependencies = [
  "proc-macro2",
- "syn 2.0.55",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4597,9 +4642,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.79"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
@@ -4639,7 +4684,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4669,7 +4714,7 @@ dependencies = [
  "arc-swap",
  "futures",
  "phi-accrual-failure-detector",
- "thiserror",
+ "thiserror 1.0.64",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -4720,15 +4765,15 @@ dependencies = [
  "asynchronous-codec",
  "bytes",
  "quick-protobuf",
- "thiserror",
+ "thiserror 1.0.64",
  "unsigned-varint 0.8.0",
 ]
 
 [[package]]
 name = "quinn"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c7c5fdde3cdae7203427dc4f0a68fe0ed09833edc525a03456b153b79828684"
+checksum = "62e96808277ec6f97351a2380e6c25114bc9e67037775464979f3037c92d05ef"
 dependencies = [
  "bytes",
  "pin-project-lite",
@@ -4737,27 +4782,30 @@ dependencies = [
  "rustc-hash 2.0.0",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
+checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
 dependencies = [
  "bytes",
+ "getrandom 0.2.15",
  "rand 0.8.5",
  "ring 0.17.8",
  "rustc-hash 2.0.0",
  "rustls",
+ "rustls-pki-types",
  "rustls-platform-verifier",
  "slab",
- "thiserror",
+ "thiserror 2.0.12",
  "tinyvec",
  "tracing",
+ "web-time",
 ]
 
 [[package]]
@@ -4798,7 +4846,7 @@ dependencies = [
  "openraft",
  "postcard",
  "serde",
- "thiserror",
+ "thiserror 1.0.64",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -5013,7 +5061,7 @@ dependencies = [
  "tempfile",
  "test-context",
  "test-log",
- "thiserror",
+ "thiserror 1.0.64",
  "tokio",
  "tokio-util",
  "tracing",
@@ -5175,7 +5223,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version 0.4.0",
- "syn 2.0.55",
+ "syn 2.0.100",
  "unicode-ident",
 ]
 
@@ -5315,12 +5363,15 @@ name = "rustls-pki-types"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
+dependencies = [
+ "web-time",
+]
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.3.4"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afbb878bdfdf63a336a5e63561b1835e7a8c91524f51621db870169eac84b490"
+checksum = "a4c7dc240fec5517e6c4eab3310438636cfe6391dfc345ba013109909a90d136"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",
@@ -5333,8 +5384,8 @@ dependencies = [
  "rustls-webpki 0.102.8",
  "security-framework",
  "security-framework-sys",
- "webpki-roots",
- "winapi",
+ "webpki-root-certs",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5514,7 +5565,7 @@ checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -5612,7 +5663,7 @@ version = "0.1.0"
 dependencies = [
  "indexmap",
  "rand 0.8.5",
- "thiserror",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -5793,7 +5844,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.55",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -5815,9 +5866,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.55"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "002a1b3dbf967edfafc32655d0f377ab0bb7b994aa1d32c8cc7e9b8bf3ebb8f0"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5833,7 +5884,7 @@ dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -5850,7 +5901,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -5913,7 +5964,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d506c7664333e246f564949bee4ed39062aa0f11918e6f5a95f553cdad65c274"
 dependencies = [
  "quote",
- "syn 2.0.55",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -5934,7 +5985,7 @@ checksum = "c8f546451eaa38373f549093fe9fd05e7d2bade739e2ddf834b9968621d60107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -5952,7 +6003,16 @@ version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.64",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -5963,7 +6023,18 @@ checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -6115,7 +6186,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -6272,7 +6343,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
 dependencies = [
  "crossbeam-channel",
- "thiserror",
+ "thiserror 1.0.64",
  "time",
  "tracing-subscriber",
 ]
@@ -6285,7 +6356,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -6595,27 +6666,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.92"
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
+ "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.100",
  "wasm-bindgen-shared",
 ]
 
@@ -6633,9 +6714,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6643,22 +6724,25 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.100",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "wc"
@@ -6707,7 +6791,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tap",
- "thiserror",
+ "thiserror 1.0.64",
  "tokio",
  "tracing",
  "vergen-pretty",
@@ -6727,7 +6811,7 @@ dependencies = [
  "postcard",
  "serde",
  "snap",
- "thiserror",
+ "thiserror 1.0.64",
  "tracing",
  "wcn_rpc",
 ]
@@ -6745,7 +6829,7 @@ dependencies = [
  "serde",
  "serde-big-array",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.64",
  "wcn_rpc",
 ]
 
@@ -6760,7 +6844,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.64",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -6808,7 +6892,7 @@ dependencies = [
  "structopt",
  "tap",
  "test-log",
- "thiserror",
+ "thiserror 1.0.64",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -6826,7 +6910,7 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "sharding",
- "thiserror",
+ "thiserror 1.0.64",
  "wcn_core",
  "wcn_rpc",
  "xxhash-rust",
@@ -6841,7 +6925,7 @@ dependencies = [
  "governor",
  "serde",
  "tap",
- "thiserror",
+ "thiserror 1.0.64",
  "time",
  "tokio",
  "tokio-serde",
@@ -6859,7 +6943,7 @@ dependencies = [
  "futures",
  "relay_rocks",
  "serde",
- "thiserror",
+ "thiserror 1.0.64",
  "time",
  "tracing",
  "wc",
@@ -6912,7 +6996,7 @@ dependencies = [
  "tap",
  "tempfile",
  "test-log",
- "thiserror",
+ "thiserror 1.0.64",
  "time",
  "tokio",
  "tokio-stream",
@@ -6957,7 +7041,7 @@ dependencies = [
  "futures",
  "raft",
  "serde",
- "thiserror",
+ "thiserror 1.0.64",
  "tracing",
  "wc",
  "wcn_rpc",
@@ -6971,7 +7055,7 @@ dependencies = [
  "futures",
  "smallvec",
  "tap",
- "thiserror",
+ "thiserror 1.0.64",
  "tokio",
  "tracing",
  "wc",
@@ -6989,9 +7073,11 @@ dependencies = [
  "derivative",
  "derive_more 1.0.0",
  "futures",
+ "governor",
  "indexmap",
  "libp2p",
  "libp2p-tls",
+ "lru 0.13.0",
  "metrics",
  "nix",
  "pin-project",
@@ -7002,7 +7088,7 @@ dependencies = [
  "serde_json",
  "socket2",
  "tap",
- "thiserror",
+ "thiserror 1.0.64",
  "tokio",
  "tokio-serde",
  "tokio-serde-postcard",
@@ -7020,7 +7106,7 @@ dependencies = [
  "arc-swap",
  "futures",
  "serde",
- "thiserror",
+ "thiserror 1.0.64",
  "time",
  "tracing",
  "wc",
@@ -7049,10 +7135,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "0.26.6"
+name = "webpki-root-certs"
+version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841c67bff177718f1d4dfefde8d8f0e78f9b6589319ba88312f567fc5841a958"
+checksum = "09aed61f5e8d2c18344b3faa33a4c837855fe56642757754775548fee21386c4"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -7324,6 +7410,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags 2.6.0",
+]
+
+[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7345,7 +7440,7 @@ dependencies = [
  "nom",
  "oid-registry",
  "rusticata-macros",
- "thiserror",
+ "thiserror 1.0.64",
  "time",
 ]
 
@@ -7381,7 +7476,7 @@ checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -7401,5 +7496,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.100",
 ]

--- a/crates/admin_api/src/server.rs
+++ b/crates/admin_api/src/server.rs
@@ -66,8 +66,10 @@ pub trait Server: Clone + Send + Sync + 'static {
             name: const { crate::RPC_SERVER_NAME.as_str() },
             addr: cfg.addr,
             keypair: cfg.keypair,
-            max_concurrent_connections: 10,
-            max_concurrent_streams: 100,
+            max_connections: 10,
+            max_connections_per_ip: 5,
+            max_connection_rate_per_ip: 10,
+            max_streams: 100,
             priority: transport::Priority::High,
         };
 

--- a/crates/client_api/src/server.rs
+++ b/crates/client_api/src/server.rs
@@ -79,8 +79,10 @@ pub trait Server: Clone + Send + Sync + 'static {
             name: const { crate::RPC_SERVER_NAME.as_str() },
             addr: cfg.addr,
             keypair: cfg.keypair.clone(),
-            max_concurrent_connections: cfg.max_concurrent_connections,
-            max_concurrent_streams: cfg.max_concurrent_streams,
+            max_connections: cfg.max_concurrent_connections,
+            max_connections_per_ip: 100,
+            max_connection_rate_per_ip: 100,
+            max_streams: cfg.max_concurrent_streams,
             priority: transport::Priority::High,
         };
 

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -42,6 +42,8 @@ backoff = { version = "0.4", features = ["tokio"] }
 tap = "1"
 socket2 = "0.5.5"
 nix = { version = "0.28", default-features = false, features = ["socket", "net"] }
+governor = { version = "0.8", default-features = false, features = ["std"] }
+lru = "0.13"
 
 [dev-dependencies]
 tracing-subscriber = "0.3"

--- a/crates/rpc/src/quic/mod.rs
+++ b/crates/rpc/src/quic/mod.rs
@@ -172,6 +172,9 @@ pub enum Error {
 
     #[error(transparent)]
     InvalidMultiaddr(#[from] InvalidMultiaddrError),
+
+    #[error("invalid connection rate limit")]
+    InvalidConnectionRate,
 }
 
 fn connection_peer_id(conn: &quinn::Connection) -> Result<PeerId, ExtractPeerIdError> {

--- a/crates/rpc/src/quic/server/filter.rs
+++ b/crates/rpc/src/quic/server/filter.rs
@@ -1,0 +1,109 @@
+use {
+    crate::quic,
+    governor::DefaultDirectRateLimiter,
+    lru::LruCache,
+    quinn::Incoming,
+    std::{
+        net::IpAddr,
+        num::{NonZeroU32, NonZeroUsize},
+        sync::Arc,
+    },
+    tokio::sync::{OwnedSemaphorePermit, Semaphore},
+    wc::metrics::{self, enum_ordinalize::Ordinalize},
+};
+
+const LOCAL_LIMITERS_LRU_CAPACITY: usize = 500;
+
+/// Connection filter.
+///
+/// Takes into account the global number of connections, number of connection
+/// from the same IP address, and number of incoming connections per second.
+pub struct Filter {
+    global_semaphore: Arc<Semaphore>,
+    local_limiters: LruCache<IpAddr, LocalLimiters>,
+    max_connection_rate: NonZeroU32,
+    max_connections_per_ip: u32,
+}
+
+impl Filter {
+    pub fn new(cfg: &super::Config) -> Result<Self, quic::Error> {
+        let max_connection_rate: NonZeroU32 = cfg
+            .max_connection_rate_per_ip
+            .try_into()
+            .map_err(|_| quic::Error::InvalidConnectionRate)?;
+
+        Ok(Self {
+            global_semaphore: Arc::new(Semaphore::new(cfg.max_connections as usize)),
+            // Safe unwrap as long as `LOCAL_LIMITERS_LRU_CAPACITY` is >0.
+            local_limiters: LruCache::new(NonZeroUsize::new(LOCAL_LIMITERS_LRU_CAPACITY).unwrap()),
+            max_connection_rate,
+            max_connections_per_ip: cfg.max_connections_per_ip,
+        })
+    }
+
+    pub fn try_acquire_permit(&mut self, incoming: &Incoming) -> Result<Permit, RejectionReason> {
+        if !incoming.remote_address_validated() {
+            return Err(RejectionReason::AddressNotValidated);
+        }
+
+        let remote_addr = incoming.remote_address().ip();
+
+        let limiters = self.local_limiters.get_or_insert(remote_addr, || {
+            LocalLimiters::new(self.max_connections_per_ip, self.max_connection_rate)
+        });
+
+        if limiters.rate_limiter.check().is_err() {
+            return Err(RejectionReason::RateLimit);
+        }
+
+        let Ok(_local) = limiters.semaphore.clone().try_acquire_owned() else {
+            return Err(RejectionReason::LocalSemaphore);
+        };
+
+        let Ok(_global) = self.global_semaphore.clone().try_acquire_owned() else {
+            return Err(RejectionReason::GlobalSemaphore);
+        };
+
+        Ok(Permit { _global, _local })
+    }
+}
+
+/// Per client IP address limiters. Consists of a semaphore and a GCRA-based
+/// rate limiter.
+struct LocalLimiters {
+    semaphore: Arc<Semaphore>,
+    rate_limiter: DefaultDirectRateLimiter,
+}
+
+impl LocalLimiters {
+    fn new(max_connections: u32, max_rate: NonZeroU32) -> Self {
+        Self {
+            semaphore: Arc::new(Semaphore::new(max_connections as usize)),
+            rate_limiter: governor::RateLimiter::direct(governor::Quota::per_second(max_rate)),
+        }
+    }
+}
+
+pub struct Permit {
+    _global: OwnedSemaphorePermit,
+    _local: OwnedSemaphorePermit,
+}
+
+#[derive(Clone, Copy, Ordinalize, PartialEq, Eq)]
+pub enum RejectionReason {
+    GlobalSemaphore,
+    LocalSemaphore,
+    RateLimit,
+    AddressNotValidated,
+}
+
+impl metrics::Enum for RejectionReason {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::GlobalSemaphore => "global_semaphore",
+            Self::LocalSemaphore => "local_semaphore",
+            Self::RateLimit => "rate_limit",
+            Self::AddressNotValidated => "address_not_validated",
+        }
+    }
+}

--- a/crates/rpc/src/test.rs
+++ b/crates/rpc/src/test.rs
@@ -131,8 +131,10 @@ async fn suite() {
             name: "test_server",
             addr: addr.clone(),
             keypair: keypair.clone(),
-            max_concurrent_connections: 500,
-            max_concurrent_streams: 10000,
+            max_connections: 500,
+            max_connections_per_ip: 100,
+            max_connection_rate_per_ip: 100,
+            max_streams: 10000,
             priority: transport::Priority::High,
         };
 

--- a/deny.toml
+++ b/deny.toml
@@ -12,6 +12,7 @@ allow = [
     "ISC",
     "BSL-1.0",
     "MPL-2.0",
+    "Zlib"
 ]
 
 exceptions = [{ name = "unicode-ident", allow = ["Unicode-DFS-2016"] }]

--- a/src/network.rs
+++ b/src/network.rs
@@ -918,8 +918,10 @@ impl Network {
             name: "raft_api",
             addr: server_addr,
             keypair: cfg.keypair.clone(),
-            max_concurrent_connections: 500,
-            max_concurrent_streams: 1000,
+            max_connections: 500,
+            max_connections_per_ip: 100,
+            max_connection_rate_per_ip: 100,
+            max_streams: 1000,
             priority: transport::Priority::High,
         };
 
@@ -948,8 +950,10 @@ impl Network {
             name: "replica_api",
             addr: socketaddr_to_multiaddr((cfg.server_addr, cfg.replica_api_server_port)),
             keypair: cfg.keypair.clone(),
-            max_concurrent_connections: cfg.replica_api_max_concurrent_connections,
-            max_concurrent_streams: cfg.replica_api_max_concurrent_rpcs,
+            max_connections: cfg.replica_api_max_concurrent_connections,
+            max_connections_per_ip: 100,
+            max_connection_rate_per_ip: 100,
+            max_streams: cfg.replica_api_max_concurrent_rpcs,
             priority: transport::Priority::High,
         };
 
@@ -1026,8 +1030,10 @@ impl Network {
             name: "migration_api",
             addr: socketaddr_to_multiaddr((cfg.server_addr, cfg.migration_api_server_port)),
             keypair: cfg.keypair.clone(),
-            max_concurrent_connections: 100,
-            max_concurrent_streams: 1000,
+            max_connections: 100,
+            max_connections_per_ip: 50,
+            max_connection_rate_per_ip: 50,
+            max_streams: 1000,
             priority: transport::Priority::Low,
         };
 


### PR DESCRIPTION
# Description

**Note: Needs to be tested on testnet first, as it can potentially break QUIC RPC.**

This adds per-IP incoming connection rate limiters for both max number of connections and for incoming connections per second.

## How Has This Been Tested?

Untested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
