### PR TITLE
feat: add tag to all replication::Driver metrics

### DIFF
--- a/crates/client_api/src/client.rs
+++ b/crates/client_api/src/client.rs
@@ -39,6 +39,9 @@ pub struct Config {
     pub auth_token_ttl: Duration,
 
     pub namespaces: Vec<auth::Auth>,
+
+    /// Additional label to be used for all metrics of the [`Server`].
+    pub metrics_tag: &'static str,
 }
 
 impl Config {
@@ -51,6 +54,7 @@ impl Config {
             auth_purpose: token::Purpose::Storage,
             auth_token_ttl: DEFAULT_AUTH_TOKEN_TTL,
             namespaces: Default::default(),
+            metrics_tag: "default",
         }
     }
 
@@ -79,6 +83,12 @@ impl Config {
 
     pub fn with_auth_ttl(mut self, ttl: Duration) -> Self {
         self.auth_token_ttl = ttl;
+        self
+    }
+
+    /// Overwrites [`Config::metrics_tag`].
+    pub fn with_metrics_tag(mut self, tag: &'static str) -> Self {
+        self.metrics_tag = tag;
         self
     }
 }

--- a/crates/rpc/src/client/mod.rs
+++ b/crates/rpc/src/client/mod.rs
@@ -42,6 +42,9 @@ pub struct Config<H = NoHandshake> {
 
 /// RPC client.
 pub trait Client<P: Sync = PeerAddr>: Send + Sync {
+    /// Returns name of the server this [`Client`] connects to.
+    fn server_name(&self) -> &ServerName;
+
     /// Sends an outbound RPC.
     fn send_rpc<'a, Fut: Future<Output = Result<Ok>> + Send + 'a, Ok: Send>(
         &'a self,

--- a/crates/rpc/src/middleware.rs
+++ b/crates/rpc/src/middleware.rs
@@ -10,6 +10,7 @@ use {
 #[derive(Clone, Debug)]
 pub struct Metered<T> {
     pub(crate) inner: T,
+    pub(crate) tag: &'static str,
 }
 
 /// RPC client or server with configured RPC timeouts.

--- a/crates/rpc/src/quic/client.rs
+++ b/crates/rpc/src/quic/client.rs
@@ -47,6 +47,10 @@ pub struct Client<H = NoHandshake> {
 impl<H> client::Marker for Client<H> {}
 
 impl<H: Handshake> crate::Client for Client<H> {
+    fn server_name(&self) -> &ServerName {
+        &self.server_name
+    }
+
     fn send_rpc<'a, Fut: Future<Output = Result<Ok>> + Send + 'a, Ok>(
         &'a self,
         peer: &'a PeerAddr,
@@ -60,6 +64,10 @@ impl<H: Handshake> crate::Client for Client<H> {
 }
 
 impl<H: Handshake> crate::Client<AnyPeer> for Client<H> {
+    fn server_name(&self) -> &ServerName {
+        &self.server_name
+    }
+
     fn send_rpc<'a, Fut: Future<Output = Result<Ok>> + Send + 'a, Ok>(
         &'a self,
         _: &'a AnyPeer,

--- a/crates/rpc/src/server/middleware.rs
+++ b/crates/rpc/src/server/middleware.rs
@@ -15,7 +15,12 @@ pub use crate::middleware::*;
 pub trait MeteredExt: Sized {
     /// Wraps `Self` with [`Metered`].
     fn metered(self) -> Metered<Self> {
-        Metered { inner: self }
+        self.metered_with_tag("default")
+    }
+
+    /// [`Self::metered`] but with additional "tag" label.
+    fn metered_with_tag(self, tag: &'static str) -> Metered<Self> {
+        Metered { inner: self, tag }
     }
 }
 
@@ -43,6 +48,8 @@ where
             .handle_rpc(id, stream, conn_info)
             .with_metrics(future_metrics!(
                 "inbound_rpc",
+                StringLabel<"server_name"> => self.config().name.as_str(),
+                StringLabel<"tag"> => self.tag,
                 StringLabel<"rpc_name"> => RpcName::new(id).as_str()
             ))
     }

--- a/crates/wcn/src/commands/storage.rs
+++ b/crates/wcn/src/commands/storage.rs
@@ -307,6 +307,7 @@ pub async fn exec(cmd: StorageCmd) -> anyhow::Result<()> {
         operation_timeout: Duration::from_millis(2500),
         nodes: [PeerAddr::new(id, addr)].into(),
         namespaces,
+        metrics_tag: "default",
     })
     .await?;
 


### PR DESCRIPTION
# Description

Adds `tag` label to replication::Driver metrics and all RPCs being used withing it (client / storage)

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
