### PR TITLE
fix(pulse-monitor): don't recreate Pulse API client on errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7029,7 +7029,7 @@ dependencies = [
  "futures",
  "postcard",
  "serde",
- "thiserror",
+ "thiserror 1.0.64",
  "tracing",
  "wcn_rpc",
 ]

--- a/crates/pulse_monitor/src/lib.rs
+++ b/crates/pulse_monitor/src/lib.rs
@@ -136,7 +136,15 @@ fn update_registry(
     // Added nodes.
     for addr in next_peers.difference(current_peers) {
         tcp_registry.insert(addr.id, EchoApiTransportFactory(addr.clone()));
-        quic_registry.insert(addr.id, PulseApiTransportFactory(addr.clone()));
+
+        if let Ok(client) = pulse_api::Client::new(addr.clone())
+            .map_err(|err| tracing::warn!(?err, "pulse_api::Client::new"))
+        {
+            quic_registry.insert(addr.id, PulseApiTransportFactory {
+                addr: addr.clone(),
+                client,
+            });
+        }
     }
 
     next_peers

--- a/crates/pulse_monitor/src/transport.rs
+++ b/crates/pulse_monitor/src/transport.rs
@@ -62,18 +62,19 @@ impl Transport for PulseApiTransport {
     }
 }
 
-pub(crate) struct PulseApiTransportFactory(pub PeerAddr);
+pub(crate) struct PulseApiTransportFactory {
+    pub addr: PeerAddr,
+    pub client: pulse_api::Client,
+}
 
 impl TransportFactory for PulseApiTransportFactory {
     type Transport = PulseApiTransport;
 
     fn address(&self) -> PeerAddr {
-        self.0.clone()
+        self.addr.clone()
     }
 
     async fn create(&self) -> Result<PulseApiTransport, pulse_api::client::Error> {
-        pulse_api::Client::new(self.0.clone())
-            .map(PulseApiTransport)
-            .map_err(|err| pulse_api::client::Error::Other(err.to_string()))
+        Ok(PulseApiTransport(self.client.clone()))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,7 @@ pub fn exec() -> anyhow::Result<()> {
 
     // TODO: Make this version consistent with the version in the repo, and find a
     // way to set it automatically.
-    wc::metrics::gauge!("wcn_node_version").set(250318.0);
+    wc::metrics::gauge!("wcn_node_version").set(250318.1);
 
     let cfg = Config::from_env().context("failed to parse config")?;
 


### PR DESCRIPTION
# Description

As Pulse API isn't yet available on all nodes, it heavily spams logs and creates new udp sockets every 3 sec.
This PR makes it so the client is being reused no matter the error.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
