### PR TITLE
fix(ci): use RELEASE_PAT

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,6 +43,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Get last tag
         if: ${{ steps.check_commits.outputs.skip != 'true' }}


### PR DESCRIPTION
# Description

Use RELEASE_PAT bot token in release CI

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
