### PR TITLE
fix: add missing client exports

### DIFF
--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -36,6 +36,7 @@ use {
 pub use {
     encryption::{Error as EncryptionError, Key as EncryptionKey},
     libp2p_identity::{Keypair, PeerId},
+    op::Output as OperationOutput,
     smart_contract::ReadError as SmartContractError,
     wcn_cluster::{CreationError as ClusterCreationError, EncryptionKey as ClusterKey},
     wcn_cluster_api::Error as ClusterError,


### PR DESCRIPTION
# Description

Adds missing client exports to implement `RequestObserver` by the API consumers.

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
