### PR TITLE
feat(terraform): remove 3 WalletConnect node operators from EU

### DIFF
--- a/infra/mainnet/main.tf
+++ b/infra/mainnet/main.tf
@@ -198,30 +198,6 @@ locals {
         local.node_config,
       ]
     }
-    wallet-connect-3 = {
-      vpc_cidr_octet = 0 # 10.0.0.0/16
-      db             = local.db_config
-      nodes = [
-        local.node_config,
-        local.node_config,
-      ]
-    }
-    wallet-connect-4 = {
-      vpc_cidr_octet = 0 # 10.0.0.0/16
-      db             = local.db_config
-      nodes = [
-        local.node_config,
-        local.node_config,
-      ]
-    }
-    wallet-connect-5 = {
-      vpc_cidr_octet = 0 # 10.0.0.0/16
-      db             = local.db_config
-      nodes = [
-        local.node_config,
-        local.node_config,
-      ]
-    }
   }
 
   us_operators = {


### PR DESCRIPTION
# Description

These deployments have been removed from the keyspace already.


## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
